### PR TITLE
feat(gulp): add error handler

### DIFF
--- a/gulp/build-css.js
+++ b/gulp/build-css.js
@@ -4,6 +4,8 @@ import postcss from 'gulp-postcss';
 import rename from 'gulp-rename';
 import sourcemaps from 'gulp-sourcemaps';
 
+import errorHandler from './error-handler';
+
 import paths from './paths';
 
 import processors from './postcss-processors';
@@ -13,6 +15,7 @@ export default () => {
   return gulp.src(paths.src.css.main)
     .pipe(sourcemaps.init())
     .pipe(postcss(processors))
+    .on('error', errorHandler)
     .pipe(rename('garden.min.css'))
     .pipe(sourcemaps.write())
     .pipe(gulp.dest(paths.src.css.dest))

--- a/gulp/docs-css.js
+++ b/gulp/docs-css.js
@@ -5,6 +5,8 @@ import postcss from 'gulp-postcss';
 import rename from 'gulp-rename';
 import sourcemaps from 'gulp-sourcemaps';
 
+import errorHandler from './error-handler';
+
 import paths from './paths';
 
 import processors from './postcss-processors';
@@ -13,6 +15,7 @@ export default () => {
   return gulp.src(paths.docs.css.main)
     .pipe(sourcemaps.init())
     .pipe(postcss(processors))
+    .on('error', errorHandler)
     .pipe(rename('style.css'))
     .pipe(sourcemaps.write())
     .pipe(gulp.dest(paths.docs.css.dest));

--- a/gulp/error-handler.js
+++ b/gulp/error-handler.js
@@ -1,0 +1,13 @@
+import notify from 'gulp-notify';
+import chalk from 'chalk';
+
+export default function(error) {
+  notify.onError({
+    title: 'PostCSS Error!',
+    message: 'Check your terminal for more information.'
+  })(error);
+
+  console.log(chalk.cyan('Message: ') + chalk.red(error.message));
+
+  this.emit('end');
+};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-plugin-transform-es2015-modules-umd": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.4.1",
+    "chalk": "^1.1.1",
     "cssnano": "^3.4.0",
     "gulp": "^3.9.0",
     "gulp-gh-pages": "^0.5.4",


### PR DESCRIPTION
As gulp-plumber was not working properly with gulp-postcss, we decided
to use `.on('errror')` to handle postCSS build errors.