### PR TITLE
chore(components): minor changes

### DIFF
--- a/src/js/components/form.js
+++ b/src/js/components/form.js
@@ -8,10 +8,8 @@ const DEFAULTS  = {
 
 class Form {
   constructor(element, options) {
-    options = $.extend({}, DEFAULTS, options || {});
-
     this._element = $(element);
-    this._options = options;
+    this._options = $.extend({}, DEFAULTS, (options || {}));
 
     this.bindListeners();
 

--- a/src/js/components/lazy-load.js
+++ b/src/js/components/lazy-load.js
@@ -12,10 +12,8 @@ const DEFAULTS = {
 
 class LazyLoad {
   constructor(element, options) {
-    options = $.extend({}, DEFAULTS, options || {});
-
     this._element = $(element);
-    this._options = options;
+    this._options = $.extend({}, DEFAULTS, (options || {}));
   }
 
   init() {

--- a/src/js/components/validation/confirm.js
+++ b/src/js/components/validation/confirm.js
@@ -1,1 +1,1 @@
-export default (field, $form) => field.value === $form.find(`[name="${field.getAttribute('data-confirm')}]`).val();
+export default (field, $form) => field.value === $form.find(`[name="${field.getAttribute('data-confirm')}"]`).val();


### PR DESCRIPTION
remove `options` from `constructor` and call `$.extend` directly in `this._options`.