### PR TITLE
Feat/open trigger option for modal component

### DIFF
--- a/docs/js/modal.md
+++ b/docs/js/modal.md
@@ -49,19 +49,21 @@ Based on this markup, the component will get all content inside of `[data-modal]
 
 ## Options
 
-Modal provides two customizable options, that is `container` and `triggerClose`. By default, `.modal` is appended in body and `triggerClose` is null.
+Modal provides three customizable options: `container`, `triggerClose` and `triggerOpen`. By default `.modal` is appended in the `body`, `triggerClose` and  `triggerOpen` are `null`.
 
-| Option            | Description |
+| Option            | Default | Description |
 |-------------------|-------------|
-| container (body)  | A new string selector to append `.modal` |
-| triggerClose (null) | A string selector to bind and call hide method when clicked |
+| container  | `"body"` | A new string selector to append `.modal` |
+| triggerClose | `null` | A string selector to bind and call hide method when clicked |
+| triggerOpen | `null` | A string selector to bind and call show method when clicked |
 
 Ex:
 
 ```js
 let options = {
   container: '.wrapper',
-  triggerClose: '[data-anything]'
+  triggerClose: '[data-anything]',
+  triggerOpen: '[data-another-thing]'
 }
 
 // as a jquery plugin
@@ -99,13 +101,9 @@ If you want that a button inside `.modal` close itself, add option `triggerClose
 
 ```js
 let modal = $('[data-modal]').modal({
-      triggerClose: '.any-selector'
-    }),
-    triggerOpen = $('[data-trigger="open"]');
-
-triggerOpen.on('click', () => {
-  modal.show();
-});
+      triggerClose: '.any-selector',
+      triggerOpen: '[data-trigger="open"]'
+    })
 ```
 Working Example:
 

--- a/docs/layout/page.jade
+++ b/docs/layout/page.jade
@@ -56,11 +56,8 @@ html(lang="pt-BR")
       $('.docs').form();
 
       var modal = $('[data-modal]').modal({
-        triggerClose: '[data-trigger="close"]'
-      });
-
-      $('[data-trigger="open"]').on('click', function() {
-        modal.data('modal').show();
+        triggerClose: '[data-trigger="close"]',
+        triggerOpen: '[data-trigger="open"]'
       });
 
       $('[data-notification-dynamic]').notification({

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -63,6 +63,12 @@ class Modal {
     $(window).off('keyup', this.handler)
   }
 
+  _bindTrigger () {
+    if (this.options.triggerOpen) {
+      $(this.options.triggerOpen).on('click', this.show.bind(this))
+    }
+  }
+
   _showModal () {
     this.$modal.addClass('modal-enter')
     this.$content.addClass('modal-content-enter')
@@ -102,6 +108,7 @@ class Modal {
 
     $(this.options.container).append(this.$modal)
 
+    this._bindTrigger()
     this._fillModal()
   }
 }

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -140,25 +140,37 @@ describe('Modal spec', () => {
       })
     )
 
-    it('should bind triggerClose if user passed selector as option',
+    it('should bind triggerClose if user passes the selector as an option',
       sinon.test(function () {
-
-        let newIstance = new Modal($fixture.find('[data-modal]'),
+        let newInstance = new Modal($fixture.find('[data-modal]'),
           { triggerClose: '[data-trigger="close"]' }
         )
 
-        newIstance.init()
-        newIstance.show()
+        newInstance.init()
+        newInstance.show()
 
-        newIstance.$modal.find('[data-trigger="close"]').trigger('click')
+        newInstance.$modal.find('[data-trigger="close"]').trigger('click')
 
-        expect(newIstance.$modal.hasClass('modal-show')).to.be.false
+        expect(newInstance.$modal.hasClass('modal-show')).to.be.false
       })
     )
+
+    it('should bind triggerOpen if user passes the selector as an option', sinon.test(function () {
+      let newInstance = new Modal($fixture.find('[data-modal]'),
+        { triggerOpen: '[data-trigger="open"]' }
+      )
+      let spy = this.spy(newInstance, 'show')
+
+      newInstance.init()
+
+      $('[data-trigger="open"]').trigger('click')
+
+      expect(spy.calledOnce).to.be.true
+    }))
   })
 
   describe('unbindListeners', () => {
-    it('should not call hide if close is clicked', sinon.test(function (){
+    it('should not call hide if close is clicked', sinon.test(function () {
       let spy = this.spy(instance, 'hide')
 
       instance.init()

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -1,225 +1,222 @@
-import Modal from '../../src/js/components/modal';
+import Modal from '../../src/js/components/modal'
+import $ from 'jquery'
 
 describe('Modal spec', () => {
-  let instance, $fixture;
+  let instance, $fixture
 
   before(() => {
-    fixture.setBase('test/fixture');
-  });
+    fixture.setBase('test/fixture')
+  })
 
   beforeEach(() => {
-    $fixture = $(fixture.load('modal.html')[0]);
+    $fixture = $(fixture.load('modal.html')[0])
 
-    instance = new Modal($fixture.find('[data-modal]'));
-  });
+    instance = new Modal($fixture.find('[data-modal]'))
+  })
 
   afterEach(() => {
-    fixture.cleanup();
-  });
+    fixture.cleanup()
+  })
 
   describe('constructor', () => {
     it('should return a instanceof $ if param element isn\'t', () => {
-      let newIstance = new Modal(fixture.load('modal.html')[0]);
+      let newIstance = new Modal(fixture.load('modal.html')[0])
 
-      expect(newIstance.$element).to.be.instanceof($);
-    });
+      expect(newIstance.$element).to.be.instanceof($)
+    })
 
     it('should have a different container to append modal', () => {
-      new Modal($fixture.find('[data-modal]'), {
-          container: '.bar'
-        }
-      );
+      let modal = new Modal($fixture.find('[data-modal]'), { container: '.bar' })
 
-      let newContainer = $fixture.find('.bar');
+      let newContainer = $fixture.find('.bar')
 
-      expect(newContainer.find('.modal')).to.exist;
-    });
-  });
+      expect(newContainer.find('.modal')).to.exist
+    })
+  })
 
   describe('init', () => {
     it('should append modal into body', () => {
-      instance.init();
+      instance.init()
 
-      expect($fixture.find('.modal')).to.exist;
-    });
+      expect($fixture.find('.modal')).to.exist
+    })
 
-    it('should call createDOM', sinon.test(function() {
-      let spy = this.spy(instance, '_createModal');
+    it('should call createDOM', sinon.test(function () {
+      let spy = this.spy(instance, '_createModal')
 
-      instance.init();
+      instance.init()
 
-      expect(spy.calledOnce).to.be.true;
-    }));
-  });
+      expect(spy.calledOnce).to.be.true
+    }))
+  })
 
   describe('show', () => {
-    it('should call _showModal', sinon.test(function() {
-      let spy = this.spy(instance, '_showModal');
+    it('should call _showModal', sinon.test(function () {
+      let spy = this.spy(instance, '_showModal')
 
-      instance.init();
-      instance.show();
+      instance.init()
+      instance.show()
 
-      expect(spy.calledOnce).to.be.true;
-    }));
+      expect(spy.calledOnce).to.be.true
+    }))
 
-    it('should call bindListeners', sinon.test(function() {
-      let spy = this.spy(instance, 'bindListeners');
+    it('should call bindListeners', sinon.test(function () {
+      let spy = this.spy(instance, 'bindListeners')
 
-      instance.init();
-      instance.show();
+      instance.init()
+      instance.show()
 
-      expect(spy.calledOnce).to.be.true;
-    }));
-  });
+      expect(spy.calledOnce).to.be.true
+    }))
+  })
 
   describe('hide', () => {
-    it('should call _hideModal', sinon.test(function() {
-      let spy = this.spy(instance, '_hideModal');
+    it('should call _hideModal', sinon.test(function () {
+      let spy = this.spy(instance, '_hideModal')
 
-      instance.init();
-      instance.hide();
+      instance.init()
+      instance.hide()
 
-      expect(spy.calledOnce).to.be.true;
-    }));
+      expect(spy.calledOnce).to.be.true
+    }))
 
-    it('should call unbindListeners', sinon.test(function() {
-      let spy = this.spy(instance, 'unbindListeners');
+    it('should call unbindListeners', sinon.test(function () {
+      let spy = this.spy(instance, 'unbindListeners')
 
-      instance.init();
-      instance.hide();
+      instance.init()
+      instance.hide()
 
-      expect(spy.calledOnce).to.be.true;
-    }));
-  });
+      expect(spy.calledOnce).to.be.true
+    }))
+  })
 
   describe('destroy', () => {
     it('should destroy modal from DOM and instance from $element', () => {
+      instance.init()
+      instance.destroy()
 
-      instance.init();
-      instance.destroy();
-
-      expect($fixture.find('.modal').length).to.equal(0);
-      expect($fixture.find('[data-modal]').data('modal')).to.be.undefined;
-    });
-  });
+      expect($fixture.find('.modal').length).to.equal(0)
+      expect($fixture.find('[data-modal]').data('modal')).to.be.undefined
+    })
+  })
 
   describe('bindListeners', () => {
-    it('should call hide if escape key is pressed', sinon.test(function() {
-      let spy = this.spy(instance, 'hide');
+    it('should call hide if escape key is pressed', sinon.test(function () {
+      let spy = this.spy(instance, 'hide')
 
-      instance.init();
-      instance.bindListeners();
+      instance.init()
+      instance.bindListeners()
 
       $(window).trigger({
         type: 'keyup',
         which: 27
-      });
+      })
 
-      expect(spy.calledOnce).to.be.true;
-    }));
+      expect(spy.calledOnce).to.be.true
+    }))
 
     it('should hide modal when click in close', () => {
-      instance.init();
-      instance.show();
+      instance.init()
+      instance.show()
 
-      instance.$close.trigger('click');
+      instance.$close.trigger('click')
 
-      expect(instance.$modal.hasClass('modal-show')).to.be.false;
-    });
+      expect(instance.$modal.hasClass('modal-show')).to.be.false
+    })
 
     it('should not call hide with user press other key instead of escape',
-      sinon.test(function() {
-        let spy = this.spy(instance, 'hide');
+      sinon.test(function () {
+        let spy = this.spy(instance, 'hide')
 
-        instance.init();
-        instance.bindListeners();
+        instance.init()
+        instance.bindListeners()
 
         $(window).trigger({
           type: 'keyup',
           which: 22
-        });
+        })
 
-        expect(spy.notCalled).to.be.true;
+        expect(spy.notCalled).to.be.true
       })
-    );
+    )
 
     it('should bind triggerClose if user passed selector as option',
-      sinon.test(function() {
+      sinon.test(function () {
 
         let newIstance = new Modal($fixture.find('[data-modal]'),
           { triggerClose: '[data-trigger="close"]' }
-        );
+        )
 
-        newIstance.init();
-        newIstance.show();
+        newIstance.init()
+        newIstance.show()
 
-        newIstance.$modal.find('[data-trigger="close"]').trigger('click');
+        newIstance.$modal.find('[data-trigger="close"]').trigger('click')
 
-        expect(newIstance.$modal.hasClass('modal-show')).to.be.false;
+        expect(newIstance.$modal.hasClass('modal-show')).to.be.false
       })
-    );
-  });
+    )
+  })
 
   describe('unbindListeners', () => {
-    it('should not call hide if close is clicked', sinon.test(function(){
-      let spy = this.spy(instance, 'hide');
+    it('should not call hide if close is clicked', sinon.test(function (){
+      let spy = this.spy(instance, 'hide')
 
-      instance.init();
-      instance.show();
-      instance.unbindListeners();
+      instance.init()
+      instance.show()
+      instance.unbindListeners()
 
-      instance.$close.trigger('click');
+      instance.$close.trigger('click')
 
-      expect(spy.notCalled).to.be.true;
-    }));
+      expect(spy.notCalled).to.be.true
+    }))
 
-    it('should not call hide if escape key is clicked', sinon.test(function(){
-      let spy = this.spy(instance, 'hide');
+    it('should not call hide if escape key is clicked', sinon.test(function () {
+      let spy = this.spy(instance, 'hide')
 
-      instance.init();
-      instance.show();
-      instance.unbindListeners();
+      instance.init()
+      instance.show()
+      instance.unbindListeners()
 
       $(window).trigger({
         type: 'keyup',
         which: 27
-      });
+      })
 
-      expect(spy.notCalled).to.be.true;
-    }));
-  });
+      expect(spy.notCalled).to.be.true
+    }))
+  })
 
   describe('_showModal', () => {
-    it('should addClass to modal and content to show enter animation', sinon.test(function(){
-      instance.init();
-      instance._showModal();
+    it('should addClass to modal and content to show enter animation', sinon.test(function () {
+      instance.init()
+      instance._showModal()
 
-      this.clock.tick(200);
+      this.clock.tick(200)
 
-      expect(instance.$modal.hasClass('modal-enter modal-show')).to.be.true;
-      expect(instance.$content.hasClass('modal-content-enter modal-content-show')).to.be.true;
-    }));
-  });
+      expect(instance.$modal.hasClass('modal-enter modal-show')).to.be.true
+      expect(instance.$content.hasClass('modal-content-enter modal-content-show')).to.be.true
+    }))
+  })
 
   describe('_hideModal', () => {
     it('should addClass to modal and content to show leave animation', () => {
-      instance.init();
-      instance._showModal();
-      instance._hideModal();
+      instance.init()
+      instance._showModal()
+      instance._hideModal()
 
-      expect(instance.$modal.hasClass('modal-leave')).to.be.true;
-      expect(instance.$content.hasClass('modal-content-leave')).to.be.true;
-    });
+      expect(instance.$modal.hasClass('modal-leave')).to.be.true
+      expect(instance.$content.hasClass('modal-content-leave')).to.be.true
+    })
 
-    it('should remove animation class from modal and content', sinon.test(function() {
-      instance.init();
-      instance.show();
-      instance.hide();
+    it('should remove animation class from modal and content', sinon.test(function () {
+      instance.init()
+      instance.show()
+      instance.hide()
 
-      this.clock.tick(200);
+      this.clock.tick(200)
 
-      expect(!instance.$modal.hasClass('modal-leave')).to.be.true;
-      expect(!instance.$modal.hasClass('modal-content-leave')).to.be.true;
-    }));
-  });
-});
+      expect(!instance.$modal.hasClass('modal-leave')).to.be.true
+      expect(!instance.$modal.hasClass('modal-content-leave')).to.be.true
+    }))
+  })
+})

--- a/test/fixture/modal.html
+++ b/test/fixture/modal.html
@@ -3,5 +3,7 @@
     foo
     <div data-trigger="close"></div>
   </div>
-  <div class="bar"></div>
+  <div class="bar">
+    <button data-trigger="open"></button>
+  </div>
 </body>


### PR DESCRIPTION
This PR should add an option to the modal component to specify an element trigger that opens the modal when clicked.

It also adjusts the coding style for `modal.spec.js` 💅 