### PR TITLE
feat(table): add table css component

### DIFF
--- a/docs/css/table.md
+++ b/docs/css/table.md
@@ -1,0 +1,156 @@
+---
+title: Table
+layout: page.jade
+sidebar: true
+collection: css
+priority: 0
+path: table
+---
+
+# Table
+
+<div class="lead">
+`table` is a component used to display a large dataset distributed in rows and columns.
+</div>
+
+## Default table
+
+To use the default table component is pretty straightforward. All you need to do is to add the class `.table` into the `table` HTML tag.
+
+<div class="example example-code">
+  <table class="table">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>First Name</th>
+        <th>Last Name</th>
+        <th>Email</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>1</th>
+        <td>Isaac</td>
+        <td>Newton</td>
+        <td>isaac@newton.com</td>
+      </tr>
+      <tr>
+        <th>2</th>
+        <td>Albert</td>
+        <td>Einstein</td>
+        <td>albert@einstein.com</td>
+      </tr>
+      <tr>
+        <th>3</th>
+        <td>Galileu</td>
+        <td>Galilei</td>
+        <td>galileu@galilei.com</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+
+```html
+  <table class="table">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>First Name</th>
+        <th>Last Name</th>
+        <th>Email</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>1</th>
+        <td>Isaac</td>
+        <td>Newton</td>
+        <td>isaac@newton.com</td>
+      </tr>
+      <tr>
+        <th>2</th>
+        <td>Albert</td>
+        <td>Einstein</td>
+        <td>albert@einstein.com</td>
+      </tr>
+      <tr>
+        <th>3</th>
+        <td>Galileu</td>
+        <td>Galilei</td>
+        <td>galileu@galilei.com</td>
+      </tr>
+    </tbody>
+  </table>
+```
+
+## Zebra Striping Tables
+
+If you want your table to alternate the colors of the rows, just add `.table-zebra` class to your `table.table` element.
+
+<div class="example example-code">
+  <table class="table table-zebra">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>First Name</th>
+        <th>Last Name</th>
+        <th>Email</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>1</th>
+        <td>Isaac</td>
+        <td>Newton</td>
+        <td>isaac@newton.com</td>
+      </tr>
+      <tr>
+        <th>2</th>
+        <td>Albert</td>
+        <td>Einstein</td>
+        <td>albert@einstein.com</td>
+      </tr>
+      <tr>
+        <th>3</th>
+        <td>Galileu</td>
+        <td>Galilei</td>
+        <td>galileu@galilei.com</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+
+```html
+  <table class="table table-zebra">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>First Name</th>
+        <th>Last Name</th>
+        <th>Email</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>1</th>
+        <td>Isaac</td>
+        <td>Newton</td>
+        <td>isaac@newton.com</td>
+      </tr>
+      <tr>
+        <th>2</th>
+        <td>Albert</td>
+        <td>Einstein</td>
+        <td>albert@einstein.com</td>
+      </tr>
+      <tr>
+        <th>3</th>
+        <td>Galileu</td>
+        <td>Galilei</td>
+        <td>galileu@galilei.com</td>
+      </tr>
+    </tbody>
+  </table>
+```

--- a/docs/styles/organisms/docs.css
+++ b/docs/styles/organisms/docs.css
@@ -64,7 +64,7 @@
     font-size: .8rem;
   }
 
-  table {
+  table:not(.table) {
     color: $color-default-dark;
     width: 100%;
 

--- a/src/css/atoms/table.css
+++ b/src/css/atoms/table.css
@@ -1,0 +1,16 @@
+.table {
+  border-collapse: collapse;
+  font-size: .8rem;
+  width: 100%;
+
+  td, th {
+    padding: .5rem;
+    text-align: left;
+  }
+}
+
+.table-zebra {
+  tbody tr:nth-child(odd) {
+    background-color: $color-default-lighter;
+  }
+}

--- a/src/css/garden.css
+++ b/src/css/garden.css
@@ -25,6 +25,7 @@
 @import "atoms/modal";
 @import "atoms/notification";
 @import "atoms/collapse";
+@import "atoms/table";
 @import "atoms/tooltip";
 
 @import "atoms/form/input";


### PR DESCRIPTION
This PR adds a table css component to garden. The component is pretty simple, it's just some base styles for a table element, with a variant class `table-zebra` to display a zebra stripes styled table.

### Default Table
![image](https://cloud.githubusercontent.com/assets/670325/17069368/a8cb3556-502c-11e6-90f7-5ee8ed8f6ac9.png)

### Zebra Table
![image](https://cloud.githubusercontent.com/assets/670325/17069379/b1623638-502c-11e6-920c-c0daf1b232fa.png)
