### PR TITLE
feat(modal): hide modal when a click is done outside its content

### DIFF
--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -77,6 +77,8 @@ class Modal {
       this.$modal.addClass('modal-show')
       this.$content.addClass('modal-content-show')
     }, 200)
+
+    this.$modal.on('click', this._onModalClick.bind(this))
   }
 
   _hideModal () {
@@ -92,6 +94,12 @@ class Modal {
       this.$modal.removeClass('modal-enter modal-leave')
       this.$content.removeClass('modal-content-enter modal-content-leave')
     }, 200)
+  }
+
+  _onModalClick (event) {
+    if (this.$modal.is(event.target)) {
+      this._hideModal()
+    }
   }
 
   _fillModal () {

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -208,6 +208,19 @@ describe('Modal spec', () => {
       expect(instance.$modal.hasClass('modal-enter modal-show')).to.be.true
       expect(instance.$content.hasClass('modal-content-enter modal-content-show')).to.be.true
     }))
+
+    context('when a click is done outside the modal\'s content', () => {
+      it('should hide the modal', sinon.test(function () {
+        let spy = this.spy(instance, '_hideModal')
+
+        instance.init()
+        instance.show()
+
+        instance.$modal.trigger('click')
+
+        expect(spy.calledOnce).to.be.true
+      }))
+    })
   })
 
   describe('_hideModal', () => {


### PR DESCRIPTION
This PR adds a typical modal behavior: when a click is done outside the modal window, it is expected the modal to be closed.

![modal-outside-click](https://cloud.githubusercontent.com/assets/670325/17373361/3c4f87c8-597e-11e6-85ac-7a199e780559.gif)
