### PR TITLE
feat(button-hollow): hollow styled buttons

### DIFF
--- a/docs/css/button.md
+++ b/docs/css/button.md
@@ -73,3 +73,51 @@ Using `<a>` element:
 ```html
 <a href="#" role="button" class="button button-disabled"></a>
 ```
+
+## Hollow Buttons
+
+If you want a hollow styled button, you can use the `.button-hollow` class. It'll display a button with a transparent background and a colored border. Like the `.button`, you can add colors using a modifier like `.button-hollow-primary`.
+
+<div class="example example-code">
+  <button type="button" class="button-hollow">
+    Default
+  </button>
+  <button type="button" class="button-hollow button-hollow-primary">
+    Primary
+  </button>
+  <button type="button" class="button-hollow button-hollow-secondary">
+    Secondary
+  </button>
+  <button type="button" class="button-hollow button-hollow-danger">
+    Danger
+  </button>
+</div>
+
+```html
+<button type="button" class="button-hollow">
+  Default
+</button>
+<button type="button" class="button-hollow button-hollow-primary">
+  Primary
+</button>
+<button type="button" class="button-hollow button-hollow-secondary">
+  Secondary
+</button>
+<button type="button" class="button-hollow button-hollow-danger">
+  Danger
+</button>
+```
+
+Likewise the standard buttons, you can achieve a disabled styled adding `.disabled` class to `.button-hollow` element.
+
+<div class="example example-code">
+  <button type="button" class="button-hollow disabled">
+    Disabled Button
+  </button>
+</div>
+
+```html
+<button type="button" class="button-hollow disabled">
+  Disabled Button
+</button>
+```

--- a/src/css/atoms/button-hollow.css
+++ b/src/css/atoms/button-hollow.css
@@ -1,0 +1,48 @@
+.button-hollow {
+  background-color: transparent;
+  border: .0625rem solid $color-default;
+  border-radius: .25rem;
+  color: $color-default;
+  display: inline-block;
+  font-size: 1rem;
+  padding: .68rem .81rem;
+  position: relative;
+  transition: background-color .3s ease-in-out;
+  z-index: 1;
+
+  &:hover,
+  &:focus {
+    background: $color-default;
+    color: $color-neutral;
+    cursor: pointer;
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &.disabled,
+  &[disabled] {
+    border-color: $color-default-light;
+    color: $color-default-light;
+    cursor: not-allowed;
+
+    &:hover,
+    &:focus {
+      background-color: transparent;
+      color: $color-default-light;
+    }
+  }
+}
+
+@each $color in primary, secondary, danger {
+
+  .button-hollow-$(color) {
+    border-color: $color-$(color);
+    color: $color-$(color);
+
+    &:hover {
+      background-color: $color-$(color);
+    }
+  }
+}

--- a/src/css/atoms/button-hollow.css
+++ b/src/css/atoms/button-hollow.css
@@ -1,24 +1,16 @@
 .button-hollow {
+  @mixin button;
+
   background-color: transparent;
   border: .0625rem solid $color-default;
-  border-radius: .25rem;
   color: $color-default;
-  display: inline-block;
-  font-size: 1rem;
-  padding: .68rem .81rem;
-  position: relative;
   transition: background-color .3s ease-in-out;
-  z-index: 1;
+  z-index: $index-front;
 
   &:hover,
   &:focus {
     background: $color-default;
     color: $color-neutral;
-    cursor: pointer;
-  }
-
-  &:focus {
-    outline: none;
   }
 
   &.disabled,

--- a/src/css/atoms/button.css
+++ b/src/css/atoms/button.css
@@ -1,14 +1,10 @@
 .button {
+  @mixin button;
+
   background-color: $color-default;
   border: 0;
-  border-radius: .25rem;
   color: $color-neutral;
-  display: inline-block;
-  font-size: 1rem;
-  padding: .68rem .81rem;
-  position: relative;
   transition: transform .3s ease-in-out;
-  z-index: 1;
 
   &::before,
   &::after {
@@ -34,12 +30,10 @@
 
   &:hover,
   &:focus {
-    text-decoration: none;
     transform: translateY(-.0625rem);
   }
 
   &:hover {
-    cursor: pointer;
 
     &::before {
       opacity: 0;
@@ -48,10 +42,6 @@
     &::after {
       opacity: 1;
     }
-  }
-
-  &:focus {
-    outline: none;
   }
 
   &.no-shadow {

--- a/src/css/garden.css
+++ b/src/css/garden.css
@@ -16,6 +16,7 @@
 @import "atoms/typography";
 @import "atoms/glyph";
 @import "atoms/button";
+@import "atoms/button-hollow";
 @import "atoms/badge";
 @import "atoms/caption";
 @import "atoms/circular";

--- a/src/css/garden.css
+++ b/src/css/garden.css
@@ -11,6 +11,7 @@
 @import "utils/mixins/column-base";
 @import "utils/mixins/push-pull-grid";
 @import "utils/mixins/disable-shadow";
+@import "utils/mixins/button";
 
 @import "atoms/box-sizing";
 @import "atoms/typography";

--- a/src/css/utils/mixins/button.css
+++ b/src/css/utils/mixins/button.css
@@ -1,0 +1,21 @@
+@define-mixin button {
+  border-radius: .25rem;
+  display: inline-block;
+  font-size: 1rem;
+  padding: .68rem .81rem;
+  position: relative;
+  z-index: $index-front;
+
+  &:focus,
+  &:hover {
+    text-decoration: none;
+  }
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &:focus {
+    outline: none;
+  }
+}


### PR DESCRIPTION
This PR adds a new style for buttons, the _hollow buttons_. They're button with transparent background and colored borders. When hovered, their background changes to a solid color.

![hollow-buttons](https://cloud.githubusercontent.com/assets/670325/17450367/25ca1338-5b36-11e6-9d47-32b5a84474e6.gif)
