### PR TITLE
fix(lazy-load): fix breakpoint parsing when a comma is on data-srcset

### DIFF
--- a/src/js/components/lazy-load.js
+++ b/src/js/components/lazy-load.js
@@ -85,8 +85,8 @@ class LazyLoad {
   parseBreakpoints (image, breakpoints) {
     image.removeAttribute('data-srcset')
 
-    breakpoints = breakpoints.split(',').map(breakpoint => {
-      breakpoint = breakpoint.trim().split(' ')
+    breakpoints = breakpoints.split(/,\s+/g).map(breakpoint => {
+      breakpoint = breakpoint.trim().split(/\s+/)
 
       return {
         src: breakpoint[0],

--- a/test/fixture/lazy-load.html
+++ b/test/fixture/lazy-load.html
@@ -1,4 +1,4 @@
 <div>
   <div data-lazy data-src class="image"></div>
-  <div data-lazy data-srcset="0.png 0, 768.png 768, 480.png 480, 1000.png 1000" class="image"></div>
+  <div data-lazy data-srcset="0,3.png 0, 768.png 768, 480.png 480, 1000.png 1000" class="image"></div>
 </div>


### PR DESCRIPTION
On lazy-load component, when an URL has a trailing comma, for instance `http://some-url.com/cortina1,40x,5,2`, the `parsingBreakpoint` method was splitting the whole string including the URL, resulting in wrongs URLs for the image src.

This PR fixes this behavior by splitting the `data-srcset` using a regex that does not include the URL.