### PR TITLE
feat(glyphs): add glyphs for order and settings

### DIFF
--- a/docs/css/glyphs.md
+++ b/docs/css/glyphs.md
@@ -215,6 +215,20 @@ You can either use it as a call IE `.glyph-cart` or as a placeholder `@extend ca
       x
     </div>
   </div>
+
+  <div class="col-xs-12 col-sm-4 col-md-3 col-lg-3">
+    <div class="glyph-container" data-clipboard-text=".glyph-x">
+      <div class="glyph glyph-settings"></div>
+      settings
+    </div>
+  </div>
+
+  <div class="col-xs-12 col-sm-4 col-md-3 col-lg-3">
+    <div class="glyph-container" data-clipboard-text=".glyph-x">
+      <div class="glyph glyph-order"></div>
+      order
+    </div>
+  </div>
 </div>
 
 ## Customizing your own bundle

--- a/src/glyphs/order.svg
+++ b/src/glyphs/order.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="300px" height="300px" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
+<rect y="51.3" class="st0" width="300" height="19.9"/>
+<rect y="111" class="st0" width="173.2" height="19.9"/>
+<rect y="230.3" class="st0" width="50.6" height="19.9"/>
+<rect y="170.6" class="st0" width="94.2" height="19.9"/>
+<g>
+
+		<rect x="187.3" y="161.2" transform="matrix(4.867910e-11 1 -1 4.867910e-11 417.0592 -74.8263)" class="st0" width="117.4" height="19.9"/>
+	<g>
+
+			<rect x="228.9" y="205.7" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 606.1242 180.22)" class="st0" width="73.6" height="19.9"/>
+
+			<rect x="189.3" y="205.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 233.5769 528.0355)" class="st0" width="73.6" height="19.9"/>
+	</g>
+</g>
+</svg>

--- a/src/glyphs/settings.svg
+++ b/src/glyphs/settings.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="300px" height="300px" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
+<g>
+	<rect x="0" y="52.3" class="st0" width="300" height="19.9"/>
+	<circle class="st0" cx="238.3" cy="62.3" r="32.7"/>
+	<rect x="0" y="141.8" class="st0" width="300" height="19.9"/>
+	<circle class="st0" cx="102.1" cy="151.8" r="32.7"/>
+	<rect x="0" y="231.3" class="st0" width="300" height="19.9"/>
+	<circle class="st0" cx="182.7" cy="241.3" r="32.7"/>
+</g>
+</svg>


### PR DESCRIPTION
This PR adds glyphs for `settings` and `order`:

![image](https://cloud.githubusercontent.com/assets/670325/18444369/5492975e-78ef-11e6-8bce-534b288e6ff5.png)

![image](https://cloud.githubusercontent.com/assets/670325/18444373/5922a688-78ef-11e6-8c7a-1bb12538d506.png)
