### PR TITLE
feat(modal): add emit `modal:show/hide` when methods are called

### DIFF
--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -1,4 +1,5 @@
 import $ from 'jquery'
+import emitter from '../utils/emitter'
 
 const NAME = 'modal'
 
@@ -21,19 +22,19 @@ class Modal {
 
   init () {
     this.$container = $(this.options.container)
-    this._createModal()
+    this.createModal()
 
     return this
   }
 
   show () {
     this.bindListeners()
-    this._showModal()
+    this.showModal()
   }
 
   hide () {
     this.unbindListeners()
-    this._hideModal()
+    this.hideModal()
   }
 
   destroy () {
@@ -64,13 +65,15 @@ class Modal {
     $(window).off('keyup', this.handler)
   }
 
-  _bindTrigger () {
+  bindTrigger () {
     if (this.options.triggerOpen) {
       $(this.options.triggerOpen).on('click', this.show.bind(this))
     }
   }
 
-  _showModal () {
+  showModal () {
+    emitter.emit('modal:show')
+
     this.$modal.addClass('modal-enter')
     this.$content.addClass('modal-content-enter')
     this.$container.addClass('no-scroll')
@@ -80,10 +83,12 @@ class Modal {
       this.$content.addClass('modal-content-show')
     }, 200)
 
-    this.$modal.on('click', this._onModalClick.bind(this))
+    this.$modal.on('click', this.onModalClick.bind(this))
   }
 
-  _hideModal () {
+  hideModal () {
+    emitter.emit('modal:hide')
+
     this.$content
       .removeClass('modal-content-show')
       .addClass('modal-content-leave')
@@ -100,17 +105,17 @@ class Modal {
     }, 200)
   }
 
-  _onModalClick (event) {
+  onModalClick (event) {
     if (this.$modal.is(event.target)) {
-      this._hideModal()
+      this.hideModal()
     }
   }
 
-  _fillModal () {
+  fillModal () {
     this.$content.find('.modal-body').append(this.$element.html())
   }
 
-  _createModal () {
+  createModal () {
     this.$modal = $(templates.modal)
     this.$content = $(templates.content)
     this.$close = $(templates.close)
@@ -120,8 +125,8 @@ class Modal {
 
     this.$container.append(this.$modal)
 
-    this._bindTrigger()
-    this._fillModal()
+    this.bindTrigger()
+    this.fillModal()
   }
 }
 

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -1,4 +1,5 @@
 import Modal from '../../src/js/components/modal'
+import emitter from '../../src/js/utils/emitter'
 import $ from 'jquery'
 
 describe('Modal spec', () => {
@@ -42,7 +43,7 @@ describe('Modal spec', () => {
     })
 
     it('should call createDOM', sinon.test(function () {
-      let spy = this.spy(instance, '_createModal')
+      let spy = this.spy(instance, 'createModal')
 
       instance.init()
 
@@ -51,8 +52,8 @@ describe('Modal spec', () => {
   })
 
   describe('show', () => {
-    it('should call _showModal', sinon.test(function () {
-      let spy = this.spy(instance, '_showModal')
+    it('should call showModal', sinon.test(function () {
+      let spy = this.spy(instance, 'showModal')
 
       instance.init()
       instance.show()
@@ -71,8 +72,8 @@ describe('Modal spec', () => {
   })
 
   describe('hide', () => {
-    it('should call _hideModal', sinon.test(function () {
-      let spy = this.spy(instance, '_hideModal')
+    it('should call hideModal', sinon.test(function () {
+      let spy = this.spy(instance, 'hideModal')
 
       instance.init()
       instance.hide()
@@ -198,10 +199,19 @@ describe('Modal spec', () => {
     }))
   })
 
-  describe('_showModal', () => {
+  describe('showModal', () => {
+    it('should emit `modal:show`', sinon.test(function () {
+      const stub = this.stub(emitter, 'emit')
+
+      instance.init()
+      instance.showModal()
+
+      expect(stub.calledWith('modal:show'))
+    }))
+
     it('should addClass to modal and content to show enter animation', sinon.test(function () {
       instance.init()
-      instance._showModal()
+      instance.showModal()
 
       this.clock.tick(200)
 
@@ -211,7 +221,7 @@ describe('Modal spec', () => {
 
     context('when a click is done outside the modal\'s content', () => {
       it('should hide the modal', sinon.test(function () {
-        let spy = this.spy(instance, '_hideModal')
+        let spy = this.spy(instance, 'hideModal')
 
         instance.init()
         instance.show()
@@ -223,11 +233,20 @@ describe('Modal spec', () => {
     })
   })
 
-  describe('_hideModal', () => {
+  describe('hideModal', () => {
+    it('should emit `modal:hide`', sinon.test(function () {
+      const stub = this.stub(emitter, 'emit')
+
+      instance.init()
+      instance.hideModal()
+
+      expect(stub.calledWith('modal:hide'))
+    }))
+
     it('should addClass to modal and content to show leave animation', () => {
       instance.init()
-      instance._showModal()
-      instance._hideModal()
+      instance.showModal()
+      instance.hideModal()
 
       expect(instance.$modal.hasClass('modal-leave')).to.be.true
       expect(instance.$content.hasClass('modal-content-leave')).to.be.true


### PR DESCRIPTION
work with emitter if someone needs to do something when modal show or hide.