### PR TITLE
fix(button-hollow): background color on focus state

### DIFF
--- a/src/css/atoms/button-hollow.css
+++ b/src/css/atoms/button-hollow.css
@@ -33,7 +33,8 @@
     border-color: $color-$(color);
     color: $color-$(color);
 
-    &:hover {
+    &:hover,
+    &:focus {
       background-color: $color-$(color);
     }
   }


### PR DESCRIPTION
The `:focus` state was missing on coloured `button-hollow` elements.