### PR TITLE
fix(form): floating label on select field when selected option is empty

### DIFF
--- a/docs/css/form.md
+++ b/docs/css/form.md
@@ -110,6 +110,27 @@ _**Obs:** When using `.helper`, don't forget to add `aria-describedby` indicate 
 </div>
 ```
 
+<div class="example example-code">
+  <div class="field">
+    <select class="select" name="select" id="select">
+      <option> </option>
+      <option>option</option>
+    </select>
+    <label for="select" class="label">Select Label</label>
+    <span class="helper" aria-describedby="name">Input Helper</span>
+  </div>
+</div>
+
+```html
+<div class="field">
+  <select class="select">
+    <option></option>
+  </select>
+  <label class="label"></label>
+  <span class="helper" aria-describedby=""></span>
+</div>
+```
+
 Please take note when using `label` + `control` on `radio|checkbox` the label will be positioned on the right side of it.
 
 <div class="example example-code">

--- a/src/js/components/form.js
+++ b/src/js/components/form.js
@@ -27,8 +27,14 @@ class Form {
     this.toggleActiveClass(event.target)
   }
 
-  shouldInputBeActive (input) {
-    return !!(input.value)
+  shouldInputBeActive ($input) {
+    let value = $input.val()
+
+    if ($input.is('select')) {
+      value = $input.find('option:selected').text().trim()
+    }
+
+    return !!(value)
   }
 
   toggleActiveClass (input) {
@@ -39,11 +45,11 @@ class Form {
       return
     }
 
-    if (!$field.hasClass('active') && this.shouldInputBeActive(input)) {
+    if (!$field.hasClass('active') && this.shouldInputBeActive($input)) {
       return $field.addClass('active')
     }
 
-    if ($field.hasClass('active') && !this.shouldInputBeActive(input)) {
+    if ($field.hasClass('active') && !this.shouldInputBeActive($input)) {
       return $field.removeClass('active')
     }
   }

--- a/test/components/form.spec.js
+++ b/test/components/form.spec.js
@@ -18,26 +18,36 @@ describe('form spec', () => {
   });
 
   describe('shouldInputBeActive', () => {
-    let input;
+    let $input;
 
     beforeEach(() => {
-      input = {};
+      $input = $fixture.find('.input');
     });
 
-    it('should return true if the input has no value/placeholder', () => {
-      expect(Form.prototype.shouldInputBeActive(input)).to.be.false;
+    it('should return false if the input has no value', () => {
+      expect(Form.prototype.shouldInputBeActive($input)).to.be.false;
     });
 
     it('should return true if the input has value', () => {
-      input.value = true;
+      $input.val(true);
 
-      expect(Form.prototype.shouldInputBeActive(input)).to.be.true;
+      expect(Form.prototype.shouldInputBeActive($input)).to.be.true;
     });
 
-    it('should return false if the input has a placeholder', () => {
-      input.placeholder = true;
+    context('when input is select field', () => {
+      beforeEach(() => {
+        $input = $fixture.find('.select');
+      });
 
-      expect(Form.prototype.shouldInputBeActive(input)).to.be.false;
+      it('should return false if the option selected has no textContent', () => {
+        expect(Form.prototype.shouldInputBeActive($input)).to.be.false;
+      });
+
+      it('should return true if the option selected has textContent', () => {
+        $input.find('option:selected').text('true');
+
+        expect(Form.prototype.shouldInputBeActive($input)).to.be.true;
+      });
     });
   });
 

--- a/test/fixture/form.html
+++ b/test/fixture/form.html
@@ -1,5 +1,8 @@
 <form>
   <fieldset class="field">
     <input type="text" class="input">
+    <select class="select">
+      <option></option>
+    </select>
   </fieldset>
 </form>


### PR DESCRIPTION
Before, we were only validating if the **value** was null, but in the case of select field is more honest validate the **textContent** is null to avoid overlap