### PR TITLE
feat(validation): filter inputs without [data-validate]

### DIFF
--- a/src/js/components/validation.js
+++ b/src/js/components/validation.js
@@ -58,8 +58,17 @@ class Validation {
   }
 
   validateAll () {
-    return Array.prototype.map.call(this.$element.find(this.options.selector), this.validate, this)
-      .every(validation => validation)
+    return Array.prototype.map.call(
+      this.getFilteredInputs(), this.validate, this
+    ).every(validation => validation)
+  }
+
+  getFilteredInputs () {
+    let inputs = this.$element.find(this.options.selector)
+
+    return inputs.filter((index, input) => {
+      return input.hasAttribute('data-validate')
+    })
   }
 }
 

--- a/test/components/validation.spec.js
+++ b/test/components/validation.spec.js
@@ -103,4 +103,24 @@ describe('Validation spec', () => {
       expect(instance.validateAll()).to.be.true
     })
   })
+
+  describe('@getFilteredInputs', () => {
+    context('inputs without [data-validate]', () => {
+      it('should be removed from jQuery object', () => {
+        instance.$element.find('#foo').removeAttr('data-validate')
+
+        expect(
+          instance.getFilteredInputs().find('#foo')
+        ).to.be.falsy
+      })
+    })
+
+    context('inputs with [data-validate]', () => {
+      it('should be in jQuery object', () => {
+        expect(
+          instance.getFilteredInputs().find('#foo').length
+        ).to.be.truthy
+      })
+    })
+  })
 })

--- a/test/fixture/validation.html
+++ b/test/fixture/validation.html
@@ -1,4 +1,4 @@
 <form>
-  <input type="text" data-required data-validate="required" value="foo">
-  <input type="text" data-required data-validate="required">
+  <input type="text" id="foo" data-required data-validate="required" value="foo">
+  <input type="text" id="bar" data-required data-validate="required">
 </form>


### PR DESCRIPTION
If we have an input with `[data-required]` but it don't have `[data-validate]`, you can't submit a form. 

~~i know that have an input with `[data-required]` and `[data-validate]` don't make sense, but it's better to prevent it :)~~

as you can see, if you have inputs without `[data-validate]`, the mapped array in `validateAll()` will return something like this:

![image](https://cloud.githubusercontent.com/assets/1045308/19399938/52432e2e-922a-11e6-89af-6e4acefa32ee.png)

and `every` will always return `false` :(
