### PR TITLE
fix(modal): prevent default behavior when open modal trigger is clicked

### DIFF
--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -67,8 +67,16 @@ class Modal {
 
   bindTrigger () {
     if (this.options.triggerOpen) {
-      $(this.options.triggerOpen).on('click', this.show.bind(this))
+      $(this.options.triggerOpen).on(
+        'click',
+        this.onTriggerOpenClick.bind(this)
+      )
     }
+  }
+
+  onTriggerOpenClick (event) {
+    event.preventDefault()
+    this.show()
   }
 
   showModal () {

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -199,6 +199,48 @@ describe('Modal spec', () => {
     }))
   })
 
+  describe('bindTrigger', () => {
+    context('when instance.options.triggerOpen is setted', () => {
+      beforeEach(() => {
+        const $triggerOpen = $('[data-trigger="open"]')
+        instance.options.triggerOpen = $triggerOpen
+      })
+
+      it('should call onTriggerOpenClick if the trigger is clicked', sinon.test(function () {
+        const stub = this.stub(instance, 'onTriggerOpenClick')
+
+        instance.init()
+        instance.bindTrigger()
+
+        $(instance.options.triggerOpen).trigger('click')
+
+        expect(stub.called).to.be.true
+      }))
+    })
+  })
+
+  describe('onTriggerOpenClick', () => {
+    it('should call preventDefault on the event', sinon.test(function () {
+      const fakeEvent = { preventDefault: () => {} }
+      const preventDefault = sinon.stub(fakeEvent, 'preventDefault')
+
+      instance.init()
+      instance.onTriggerOpenClick(fakeEvent)
+
+      expect(preventDefault.calledOnce).to.be.true
+    }))
+
+    it('should call instance.show()', sinon.test(function () {
+      const fakeEvent = { preventDefault: () => {} }
+      const show = sinon.stub(instance, 'show')
+
+      instance.init()
+      instance.onTriggerOpenClick(fakeEvent)
+
+      expect(show.calledOnce).to.be.true
+    }))
+  })
+
   describe('showModal', () => {
     it('should emit `modal:show`', sinon.test(function () {
       const stub = this.stub(emitter, 'emit')


### PR DESCRIPTION
It's common to have an anchor as the trigger to open the modal. Sometimes we want to keep its `href` attribute, but we do not want to be redirected. So it would be really nice to prevent the default behavior of this element. This PR does that.