### PR TITLE
Run styles:docs only after build is finished

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,8 +35,8 @@ gulp.task('default',
   gulp.series(
     'clean',
     'metalsmith',
-    'styles:docs',
     'build',
+    'styles:docs',
     'server',
     'watch'
   )

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A styleguide based on Leroy Merlin needs",
   "main": "dist/js/garden.min.js",
   "scripts": {
+    "start": "gulp",
     "gulp": "gulp",
     "test": "karma start",
     "test:ci": "karma start --single-run --reporters dots,coverage -R spec",


### PR DESCRIPTION
This PR changes the gulp default task to run the `build` task before `styles:docs` task to avoid possible errors when running the default task for first time.

Also, this PR adds a npm start script as the gulp default task.