### PR TITLE
feat(static-modal): add options to avoid user to close modal

### DIFF
--- a/docs/js/modal.md
+++ b/docs/js/modal.md
@@ -56,6 +56,8 @@ Modal provides three customizable options: `container`, `triggerClose` and `trig
 | container  | `"body"` | A new string selector to append `.modal` |
 | triggerClose | `null` | A string selector to bind and call hide method when clicked |
 | triggerOpen | `null` | A string selector to bind and call show method when clicked |
+| static | false | When false insert the close icon and call hide method when clicked outside modal  |
+| keyboard | true | Closes the modal when esc key is pressed |
 
 Ex:
 
@@ -63,7 +65,9 @@ Ex:
 let options = {
   container: '.wrapper',
   triggerClose: '[data-anything]',
-  triggerOpen: '[data-another-thing]'
+  triggerOpen: '[data-another-thing]',
+  static: false,
+  keyboard: true
 }
 
 // as a jquery plugin
@@ -75,9 +79,10 @@ new Modal(document.querySelectorAll('[data-modal]'), options);
 
 ## Methods
 
-`.show()`: manually opens modal and bind close icon and `esc` keyboard key.
+`.show()`: manually opens modal and bind close icon and `esc` keyboard key by default.
 
 `.hide()`: manually closes modal and unbind close icon and `esc` keyboard key.
+
 
 ## Working with modal
 
@@ -118,3 +123,16 @@ Working Example:
     </div>
   </div>
 </div>
+
+## Static modal
+
+It's possible to use a modal in cases where a user interaction is mandatory before closing the modal.
+With the `static` and `keyboard` options, you can turn off the options to close the modal.
+You need to call the `.hide()` function manually.
+
+```js
+let modal = $('[data-modal]').modal({
+      static: true,
+      keyboard: false
+    })
+```

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -14,7 +14,8 @@ const DEFAULTS = {
   triggerClose: null,
   static: false,
   keyboard: true,
-  keys: { esc: 27 }
+  keys: { esc: 27 },
+  triggerOpen: null
 }
 
 class Modal {

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -11,7 +11,10 @@ const templates = {
 
 const DEFAULTS = {
   container: 'body',
-  triggerClose: null
+  triggerClose: null,
+  static: false,
+  keyboard: true,
+  keys: { esc: 27 }
 }
 
 class Modal {
@@ -49,11 +52,20 @@ class Modal {
 
     this.$close.on('click', this.hide.bind(this))
 
-    $(window).on('keyup', this.handler = (e) => {
-      if (e.which === 27) {
-        this.hide()
-      }
-    })
+    this.bindKeyboardListener()
+  }
+
+  bindKeyboardListener () {
+    if (this.options.keyboard) {
+      $(window).on('keyup', (e) => {
+        const { esc } = this.options.keys
+        const key = e.which
+
+        if (key === esc) {
+          this.hide()
+        }
+      })
+    }
   }
 
   unbindListeners () {
@@ -114,7 +126,7 @@ class Modal {
   }
 
   onModalClick (event) {
-    if (this.$modal.is(event.target)) {
+    if (!this.isStaticModal() && this.$modal.is(event.target)) {
       this.hideModal()
     }
   }
@@ -128,13 +140,20 @@ class Modal {
     this.$content = $(templates.content)
     this.$close = $(templates.close)
 
-    this.$content.append(this.$close)
+    if (!this.isStaticModal()) {
+      this.$content.append(this.$close)
+    }
+
     this.$modal.append(this.$content)
 
     this.$container.append(this.$modal)
 
     this.bindTrigger()
     this.fillModal()
+  }
+
+  isStaticModal () {
+    return this.options.static
   }
 }
 


### PR DESCRIPTION
Added booleans options `static` and `keyboard`.
With this options the modal cannot be closed by the user. It's possible to use a modal in cases where a user interaction is mandatory.

When passing true to `static`, the icon `X` to close the modal are not inserted, clicking outside the modal don't close the modal. The default value is `false`.

When passing `false` to `keyboard`, the `esc` key don't close the modal. Default value is `true`.