### PR TITLE
feat(select): Open select options on label click

### DIFF
--- a/src/css/atoms/form/select.css
+++ b/src/css/atoms/form/select.css
@@ -1,6 +1,6 @@
 .select {
   @mixin form-component default, primary-dark {
-    background-color: $color-neutral;
+    background-color: transparent;
     font-size: 1.1rem;
     height: 2.5rem;
   }

--- a/src/css/molecules/field.css
+++ b/src/css/molecules/field.css
@@ -23,6 +23,10 @@
     }
   }
 
+  .select + .label {
+    z-index: $index-rear;
+  }
+
   input[type="checkbox"],
   input[type="radio"] {
     margin-right: .31rem;


### PR DESCRIPTION
The desired behavior for when users click the label within a select tag is to open the select options. That is not a common behavior for selects so in order to achieve that the CSS for the label and the select tag was modified a little bit. Now the label stands behind the select, which has a transparent background. With that, all the clicks, including the ones on a label, will now be registered on the select block.