### PR TITLE
feat(alert): Add Alert component

### DIFF
--- a/docs/js/alert.md
+++ b/docs/js/alert.md
@@ -8,7 +8,7 @@ path: alert
 ---
 
 # Alert
-<p class="lead">The Alert component is an empty container where you can add a message that will be presented to users. It has an OK button by default.</p>
+<p class="lead">The alert component is an empty container where you can add a message that will be presented to users. It has an OK button by default.</p>
 
 An alert box is often used when you want to make sure information comes through to the user.
 
@@ -31,19 +31,21 @@ new Alert(options);
 
 ## Options
 
-Alert provides two customizable options: `textMessage` and `textButton`. The default value for the  `textMessage` is `this is an example message` and for the `textButton` is `Ok`.
+The alert provides some customizable options such as: `textMessage`, `textButton`, `size`, and `triggerClose`. The default value for the `textMessage` is 'This is an example message', for the `textButton` is 'Ok', the `size` value is 'medium', and `triggerClose` is 'data-alert-button'.
 
 | Option            | Default | Description |
 |-------------------|-------------|
-| textMessage  | `this is an example message` | A text to display in the alert |
-| textButton | `Ok` | A text to alert button |
+| textMessage  | `This is an example message` | A text to display in the alert |
+| textButton | `Ok` | A text to the alert button |
+| size | `"medium"` | The modal size may vary between small, large, or medium |
+| triggerClose | `data-alert-button` | A string selector to bind and call the hide method when clicked |
 
 
 Ex:
 
 ```js
 let options = {
-  textMessage: 'this is an example message',
+  textMessage: 'This is an example message',
   textButton: 'Ok'
 }
 
@@ -54,10 +56,41 @@ $('[data-alert]').on('click', () => $.fn.alert(options));
 new Alert(options);
 ```
 
-Working Example:
+## Working with alert
 
-<button class="button button-primary" data-alert>Open Alert</button>
+By default, an alert provides a text message, a text to the button, and a size value. Here's an example on how to create a button to open an alert.
 
-### Notes
+<div class="example example-code">
+  <button class="button button-primary" data-alert>Open Alert</button>
+</div>
+
+```js
+let alert = $('[data-alert]').on('click', () => $.fn.alert());
+```
+ The alert can be closed by clicking on the close icon or by pressing the `esc` key.
+
+ An alert has a default close button, but you can use `triggerClose` option to change the element from which the click event will close the alert. Example:
+
+```js
+$('[data-alert]').on('click', () => $.fn.alert({
+  triggerClose: '.any-selector'
+}));
+```
+
+## Set Alert size
+
+The alert has three predefined sizes: small, medium, or large.
+
+<div class="example example-code align-center">
+  <button class="button button-primary" data-alert-small>Open Small Alert</button>
+  <button class="button button-primary" data-alert-medium>Open Medium Alert</button>
+  <button class="button button-primary" data-alert-large>Open Large Alert</button>
+</div>
+
+```js
+$('[data-alert]').on('click', () => $.fn.alert({ size: 'small|medium|large' }));
+```
+
+## Notes
 
 The alert dialog should be used for messages that do not require any response on the part of the user, other than the acknowledgement of the message.

--- a/docs/js/alert.md
+++ b/docs/js/alert.md
@@ -1,0 +1,40 @@
+---
+title: Alert
+layout: page.jade
+sidebar: true
+collection: js
+priority: 3
+path: alert
+---
+
+# Alert
+<p class="lead">The Alert component is an empty container where you can add a message that will be presented to users. It has an OK button by default.</p>
+
+An alert box is often used when you want to make sure information comes through to the user.
+
+### How to use
+
+You can initiate the component as a jQuery plugin:
+
+```js
+// using a data attribute
+$('[data-alert]').on('click', () => $.fn.alert('this is an example message'))
+
+// using a class
+$('.data-alert').on('click', () => $.fn.alert('this is an example message'))
+```
+or a vanilla constructor:
+
+```js
+import Alert from 'garden/src/js/components/alert';
+
+new Alert('message');
+```
+
+Working Example:
+
+<button class="button button-primary" data-alert>Open Alert</button>
+
+### Notes
+
+The alert dialog should be used for messages that do not require any response on the part of the user, other than the acknowledgement of the message.

--- a/docs/js/alert.md
+++ b/docs/js/alert.md
@@ -17,18 +17,41 @@ An alert box is often used when you want to make sure information comes through 
 You can initiate the component as a jQuery plugin:
 
 ```js
-// using a data attribute
-$('[data-alert]').on('click', () => $.fn.alert('this is an example message'))
-
-// using a class
-$('.data-alert').on('click', () => $.fn.alert('this is an example message'))
+// using any selector
+$('any-selector').on('click', () => $.fn.alert(options));
 ```
+
 or a vanilla constructor:
 
 ```js
 import Alert from 'garden/src/js/components/alert';
 
-new Alert('message');
+new Alert(options);
+```
+
+## Options
+
+Alert provides two customizable options: `textMessage` and `textButton`. The default value for the  `textMessage` is `this is an example message` and for the `textButton` is `Ok`.
+
+| Option            | Default | Description |
+|-------------------|-------------|
+| textMessage  | `this is an example message` | A text to display in the alert |
+| textButton | `Ok` | A text to alert button |
+
+
+Ex:
+
+```js
+let options = {
+  textMessage: 'this is an example message',
+  textButton: 'Ok'
+}
+
+// as a jquery plugin
+$('[data-alert]').on('click', () => $.fn.alert(options));
+
+// as a vanilla constructor
+new Alert(options);
 ```
 
 Working Example:

--- a/docs/layout/page.jade
+++ b/docs/layout/page.jade
@@ -59,6 +59,8 @@ html(lang="pt-BR")
         triggerClose: '[data-trigger="close"]',
         triggerOpen: '[data-trigger="open"]'
       });
+            
+      var alert = $('[data-alert]').on('click', () => $.fn.alert('this is an example message'))
 
       $('[data-modal-small]').modal({
         triggerOpen: '[data-trigger-small="open"]',

--- a/docs/layout/page.jade
+++ b/docs/layout/page.jade
@@ -60,7 +60,7 @@ html(lang="pt-BR")
         triggerOpen: '[data-trigger="open"]'
       });
             
-      var alert = $('[data-alert]').on('click', () => $.fn.alert('this is an example message'))
+      var alert = $('[data-alert]').on('click', () => $.fn.alert());
 
       $('[data-modal-small]').modal({
         triggerOpen: '[data-trigger-small="open"]',

--- a/docs/layout/page.jade
+++ b/docs/layout/page.jade
@@ -59,8 +59,6 @@ html(lang="pt-BR")
         triggerClose: '[data-trigger="close"]',
         triggerOpen: '[data-trigger="open"]'
       });
-            
-      var alert = $('[data-alert]').on('click', () => $.fn.alert());
 
       $('[data-modal-small]').modal({
         triggerOpen: '[data-trigger-small="open"]',
@@ -93,6 +91,24 @@ html(lang="pt-BR")
       trigger.on('click', function() {
         modalTrigger.show();
       });
+      
+      $('[data-alert]').on('click', () => $.fn.alert());
+
+      $('[data-alert-small]').on('click', () => $.fn.alert({
+        textMessage: 'Small alert example message',
+        size: 'small'
+      }));
+      
+      $('[data-alert-medium]').on('click', () => $.fn.alert({
+        textMessage: 'Medium alert example message',
+        size: 'medium'
+      }));
+      
+      $('[data-alert-large]').on('click', () => $.fn.alert({
+        textMessage: 'Large alert example message',
+        size: 'large'
+      }));
+      
 
       $('[data-notification-dynamic]').notification({
         message: 'foo bar',

--- a/src/css/atoms/button.css
+++ b/src/css/atoms/button.css
@@ -89,7 +89,3 @@
     text-decoration: none;
   }
 }
-
-.button-full {
-  width: 100%;
-}

--- a/src/js/components/alert.js
+++ b/src/js/components/alert.js
@@ -3,30 +3,60 @@ import Modal from './modal'
 
 const NAME = 'alert'
 
-const templates = {
-  wrapper: '<div></div>',
-  content: '<div class="container-fluid align-center"></div>',
-  wrapperText: '<div class="row"><div class="col-xs-12"><p data-alert-text></p></div></div>',
-  button: '<div class="row"><div class="col-xs-offset-2 col-xs-8 col-md-offset-4 col-md-4"><button class="button button-primary button-full" data-alert-button>Ok</button></div></div>'
+const DEFAULTS = {
+  textMessage: 'this is an example message',
+  textButton: 'Ok',
+  triggerClose: '[data-alert-button]'
 }
 
-class Alert extends Modal {
-  constructor (message) {
-    const { content, wrapperText, button, wrapper } = templates
-    const $alert = $(content).append(wrapperText, button)
-    const $element = $(wrapper).append($alert)
+class Alert {
+  constructor (options = {}) {
+    this.options = $.extend({}, DEFAULTS, options)
+  }
 
-    $element.find('[data-alert-text]').append(message)
+  init () {
+    this.setupAlert()
+    this.showAlert()
+  }
 
-    super($element, {
-      triggerClose: '[data-alert-button]'
-    })
+  setupAlert () {
+    const { textMessage, textButton, triggerClose } = this.options
+    this.$element = $(this.buildHtml(textMessage, textButton))
+
+    this.modal = $(this.$element).modal({ triggerClose }).data('modal')
+  }
+
+  showAlert () {
+    this.modal.show()
+  }
+
+  buildHtml (textMessage, textButton) {
+    return (`
+      <div>
+        <div class="container-fluid align-center">
+          <div class="row">
+            <div class="col-xs-12">
+              <p data-alert-text>${textMessage}</p>
+            </div>
+            <div class="row">
+              <div class="col-xs-offset-2 col-xs-8 col-md-offset-4 col-md-4">
+                <button class="button button-primary button-full" data-alert-button>
+                  ${textButton}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `)
   }
 }
 
 /* istanbul ignore next */
-$.fn[NAME] = function (message) {
-  return $.data(this, NAME, new Alert(message).init().show())
+$.fn[NAME] = function (options) {
+  return $.data(this, NAME, new Alert(options).init())
 }
 
-export default (message) => new Alert(message).init()
+/* istanbul ignore next */
+export default (options) => new Alert(options).init()
+export { Alert }

--- a/src/js/components/alert.js
+++ b/src/js/components/alert.js
@@ -4,8 +4,9 @@ import Modal from './modal'
 const NAME = 'alert'
 
 const DEFAULTS = {
-  textMessage: 'this is an example message',
+  textMessage: 'This is an example message',
   textButton: 'Ok',
+  size: 'medium',
   triggerClose: '[data-alert-button]'
 }
 
@@ -20,14 +21,18 @@ class Alert {
   }
 
   setupAlert () {
-    const { textMessage, textButton, triggerClose } = this.options
+    const { textMessage, textButton, size, triggerClose } = this.options
     this.$element = $(this.buildHtml(textMessage, textButton))
 
-    this.modal = $(this.$element).modal({ triggerClose }).data('modal')
+    this.modal = $(this.$element).modal({ triggerClose, size }).data('modal')
   }
 
   showAlert () {
     this.modal.show()
+  }
+
+  hideAlert () {
+    this.modal.hide()
   }
 
   buildHtml (textMessage, textButton) {

--- a/src/js/components/alert.js
+++ b/src/js/components/alert.js
@@ -1,0 +1,32 @@
+import $ from 'jquery'
+import Modal from './modal'
+
+const NAME = 'alert'
+
+const templates = {
+  wrapper: '<div></div>',
+  content: '<div class="container-fluid align-center"></div>',
+  wrapperText: '<div class="row"><div class="col-xs-12"><p data-alert-text></p></div></div>',
+  button: '<div class="row"><div class="col-xs-offset-2 col-xs-8 col-md-offset-4 col-md-4"><button class="button button-primary button-full" data-alert-button>Ok</button></div></div>'
+}
+
+class Alert extends Modal {
+  constructor (message) {
+    const { content, wrapperText, button, wrapper } = templates
+    const $alert = $(content).append(wrapperText, button)
+    const $element = $(wrapper).append($alert)
+
+    $element.find('[data-alert-text]').append(message)
+
+    super($element, {
+      triggerClose: '[data-alert-button]'
+    })
+  }
+}
+
+/* istanbul ignore next */
+$.fn[NAME] = function (message) {
+  return $.data(this, NAME, new Alert(message).init().show())
+}
+
+export default (message) => new Alert(message).init()

--- a/test/components/alert.spec.js
+++ b/test/components/alert.spec.js
@@ -1,33 +1,73 @@
 import $ from 'jquery'
-import Alert from '../../src/js/components/alert'
-import Modal from '../../src/js/components/modal'
+import { Alert } from '../../src/js/components/alert'
 
-describe('Alert spec', () => {
-  let instance, $fixture
-
-  before(() => {
-    fixture.setBase('test/fixture')
-  })
+describe('Alert component', () => {
+  let instance
 
   beforeEach(() => {
-    $fixture = $(fixture.load('alert.html')[0])
-
-    instance = new Alert($fixture.find('[data-alert]'))
+    instance = new Alert($('<div />'))
   })
 
-  afterEach(() => {
-    fixture.cleanup()
-  })
+  describe('@init', () => {
+    it('should call @setupAlert', sinon.test(function () {
+      const stub = this.stub(instance, 'setupAlert')
+      this.stub(instance, 'showAlert')
 
-  describe('constructor', () => {
-    it('should properly call super', sinon.test(function () {
-      const stub = this.stub(Modal.prototype, 'constructor')
+      instance.init()
 
-      let alert = new Alert('test')
-
-      expect(stub.calledWith(instance.$element, {
-        triggerOpen: '[data-trigger="open"]'
-      }))
+      expect(stub.calledOnce).to.be.true
     }))
+
+    it('should call @showAlert', sinon.test(function () {
+      const stub = this.stub(instance, 'showAlert')
+      this.stub(instance, 'setupAlert')
+
+      instance.init()
+
+      expect(stub.calledOnce).to.be.true
+    }))
+  })
+
+  describe('@setupAlert', () => {
+    it('should properly assign $element', () => {
+      instance.$element = undefined
+
+      instance.setupAlert()
+
+      expect(instance.$element).to.not.be.undefined
+    })
+
+    it('should properly assign modal', () => {
+      instance.modal = undefined
+
+      instance.setupAlert()
+
+      expect(instance.modal).to.not.be.undefined
+    })
+  })
+
+  describe('@showAlert', () => {
+    it('should show the alert component', sinon.test(function () {
+      instance.modal = { show () {} }
+      const stub = this.stub(instance.modal, 'show')
+
+      instance.showAlert()
+
+      expect(stub.calledOnce).to.be.true
+    }))
+  })
+
+  describe('@buildHtml', () => {
+    it('should have the data-alert-text', () => {
+      const html = instance.buildHtml('string', 'string')
+
+      expect($(html).find('[data-alert-text]')).to.not.be.undefined
+    })
+
+    it('should have the data-alert-button', () => {
+      const html = instance.buildHtml('string', 'string')
+
+      expect($(html).find('[data-alert-button]')).to.not.be.undefined
+    })
   })
 })

--- a/test/components/alert.spec.js
+++ b/test/components/alert.spec.js
@@ -1,0 +1,33 @@
+import $ from 'jquery'
+import Alert from '../../src/js/components/alert'
+import Modal from '../../src/js/components/modal'
+
+describe('Alert spec', () => {
+  let instance, $fixture
+
+  before(() => {
+    fixture.setBase('test/fixture')
+  })
+
+  beforeEach(() => {
+    $fixture = $(fixture.load('alert.html')[0])
+
+    instance = new Alert($fixture.find('[data-alert]'))
+  })
+
+  afterEach(() => {
+    fixture.cleanup()
+  })
+
+  describe('constructor', () => {
+    it('should properly call super', sinon.test(function () {
+      const stub = this.stub(Modal.prototype, 'constructor')
+
+      let alert = new Alert('test')
+
+      expect(stub.calledWith(instance.$element, {
+        triggerOpen: '[data-trigger="open"]'
+      }))
+    }))
+  })
+})

--- a/test/components/alert.spec.js
+++ b/test/components/alert.spec.js
@@ -57,6 +57,17 @@ describe('Alert component', () => {
     }))
   })
 
+  describe('@hideAlert', () => {
+    it('should hide the alert component', sinon.test(function () {
+      instance.modal = { hide () {} }
+      const stub = this.stub(instance.modal, 'hide')
+
+      instance.hideAlert()
+
+      expect(stub.calledOnce).to.be.true
+    }))
+  })
+
   describe('@buildHtml', () => {
     it('should have the data-alert-text', () => {
       const html = instance.buildHtml('string', 'string')

--- a/test/fixture/alert.html
+++ b/test/fixture/alert.html
@@ -1,4 +1,0 @@
-<div data-alert>
-  <p data-alert-text></p>
-  <div data-alert-button data-trigger="close"></div>
-</div>

--- a/test/fixture/alert.html
+++ b/test/fixture/alert.html
@@ -1,0 +1,4 @@
+<div data-alert>
+  <p data-alert-text></p>
+  <div data-alert-button data-trigger="close"></div>
+</div>


### PR DESCRIPTION
Add the Alert component extends the actual modal component using JQuery plugin.

Alert provides some customizable options such as: textMessage, textButton, size, and triggerClose. 

Docs: 
![image](https://cloud.githubusercontent.com/assets/17216397/21900599/97c1da70-d8db-11e6-998f-21063ab86500.png)

Alert: 
![image](https://cloud.githubusercontent.com/assets/17216397/21817571/a949a75a-d74b-11e6-8983-9b72daba713a.png)

