### PR TITLE
feat(select): Open select option on label click

### DIFF
--- a/src/css/molecules/field.css
+++ b/src/css/molecules/field.css
@@ -23,6 +23,10 @@
     }
   }
 
+  .select + .label {
+    pointer-events: none;
+  }
+
   input[type="checkbox"],
   input[type="radio"] {
     margin-right: .31rem;


### PR DESCRIPTION
Ignores the click on the `label` and open the options in the `select` form element.