### PR TITLE
feat(modal): Add size option to modal component

### DIFF
--- a/docs/js/modal.md
+++ b/docs/js/modal.md
@@ -92,7 +92,7 @@ By default, modal don't provide any trigger to open it. Where's an example of ho
 </div>
 
 ```js
-let modal = $('[data-modal-trigger]').modal().data('modal')
+let modal = $('[data-modal-trigger]').modal().data('modal');
 let trigger = $('[data-trigger]');
 
 trigger.on('click', () => {
@@ -116,7 +116,7 @@ To have a default open and close button, you can use `triggerOpen` and `triggerC
 $('[data-modal]').modal({
   triggerClose: '.any-selector',
   triggerOpen: '[data-trigger="open"]'
-})
+});
 ```
 
 ## Set Modal size
@@ -174,10 +174,10 @@ You need to call the `.hide()` function manually.
 let modalStatic = $('[data-modal-static]').modal({
   static: true,
   keyboard: false
-}).data('modal')
+}).data('modal');
 
 function closeModalStatic() {
-  modalStatic.hide()
+  modalStatic.hide();
 }
 ```
 

--- a/docs/js/modal.md
+++ b/docs/js/modal.md
@@ -17,11 +17,8 @@ Modal component allow users to choose which selector to use, you can use a simpl
 You can initiate as a jQuery plugin:
 
 ```js
-// using a data-*
-$('[data-modal]').modal(options);
-
-// using a class
-$('.modal-wrapper').modal(options);
+// using any selector
+$('any-selector').modal(options);
 ```
 
 or a vanilla constructor:
@@ -49,11 +46,12 @@ Based on this markup, the component will get all content inside of `[data-modal]
 
 ## Options
 
-Modal provides three customizable options: `container`, `triggerClose` and `triggerOpen`. By default `.modal` is appended in the `body`, `triggerClose` and  `triggerOpen` are `null`.
+Modal provides some customizable options as: `container`, `size`, `triggerClose` and `triggerOpen`. The default of `.modal` is to be appended in the `body`, the `size` is 'medium', `triggerClose` and  `triggerOpen` are `null`.
 
 | Option            | Default | Description |
 |-------------------|-------------|
 | container  | `"body"` | A new string selector to append `.modal` |
+| size | `"medium"` | Size of the modal, can be "small", "large" or "medium" |
 | triggerClose | `null` | A string selector to bind and call hide method when clicked |
 | triggerOpen | `null` | A string selector to bind and call show method when clicked |
 | static | false | When false insert the close icon and call hide method when clicked outside modal  |
@@ -64,6 +62,7 @@ Ex:
 ```js
 let options = {
   container: '.wrapper',
+  size: 'small',
   triggerClose: '[data-anything]',
   triggerOpen: '[data-another-thing]',
   static: false,
@@ -110,11 +109,63 @@ let modal = $('[data-modal]').modal({
       triggerOpen: '[data-trigger="open"]'
     })
 ```
-Working Example:
 
-<button class="button button-primary" data-trigger="open">Open Modal</button>
+## How to set the modal size
 
-<div data-modal class="hide">
+The modal has three predefined sizes that can be chosen, small, medium or large.
+
+```js
+//small
+let options = {
+  size: 'small'
+}
+
+//medium
+let options = {
+  size: 'medium'
+}
+
+//large
+let options = {
+  size: 'large'
+}
+
+// as a jquery plugin
+$('[data-modal]').modal(options);
+
+// as a vanilla constructor
+new Modal(document.querySelectorAll('[data-modal]'), options);
+```
+
+### Working buttons examples
+
+<div class="example example-code align-center">
+  <button class="button button-primary" data-trigger-small="open">Open Small Modal</button>
+  <button class="button button-primary" data-trigger-medium="open">Open Medium Modal</button>
+  <button class="button button-primary" data-trigger-large="open">Open Large Modal</button>
+</div>
+
+<div data-modal-small class="hide">
+  <div class="row">
+    <div class="col-xs-12">
+      <h2>hello</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <button class="button button-primary" data-trigger="close">Close</button>
+    </div>
+  </div>
+</div>
+
+<div data-modal-medium class="hide">
+  <div class="row">
+    <div class="col-xs-12">
+      <h2>hello</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <button class="button button-primary" data-trigger="close">Close</button>
+    </div>
+  </div>
+</div>
+
+<div data-modal-large class="hide">
   <div class="row">
     <div class="col-xs-12">
       <h2>hello</h2>

--- a/docs/js/modal.md
+++ b/docs/js/modal.md
@@ -12,9 +12,9 @@ path: modal
 
 ## How to
 
-Modal component allow users to choose which selector to use, you can use a simple `[data-whatever]` or a class. Be sure to not use class like: `.modal`, `.modal-content`, `.modal-body` to initiate modal. Modal has variable `height` based on his content and the `max-height` is `90%`.
+Modal component allows users to choose which selector to use, you can use a simple `[data-whatever]` or a class. Be sure to not use classes such as: `.modal`, `.modal-content`, and `.modal-body` to initiate a modal. Modal has variable `height` based on it content and the `max-height` is `90%`.
 
-You can initiate as a jQuery plugin:
+You can initiate it as a jQuery plugin:
 
 ```js
 // using any selector
@@ -46,12 +46,12 @@ Based on this markup, the component will get all content inside of `[data-modal]
 
 ## Options
 
-Modal provides some customizable options as: `container`, `size`, `triggerClose` and `triggerOpen`. The default of `.modal` is to be appended in the `body`, the `size` is 'medium', `triggerClose` and  `triggerOpen` are `null`.
+Modal provides some customizable options such as: `container`, `size`, `triggerClose`, and `triggerOpen`. The default container option for the `.modal` class is to be appended in the `body`, the `size` is 'medium', `triggerClose`, and  `triggerOpen` are `null`.
 
 | Option            | Default | Description |
 |-------------------|-------------|
-| container  | `"body"` | A new string selector to append `.modal` |
-| size | `"medium"` | Modal sizes that can be "small", "large" or "medium" |
+| container  | `"body"` | A new string selector in which the modal component will be appended |
+| size | `"medium"` | The modal size may vary between small, large, or medium |
 | triggerClose | `null` | A string selector to bind and call hide method when clicked |
 | triggerOpen | `null` | A string selector to bind and call show method when clicked |
 | static | false | When false insert the close icon and call hide method when clicked outside modal  |
@@ -85,7 +85,7 @@ new Modal(document.querySelectorAll('[data-modal]'), options);
 
 ## Working with modal
 
-By default, modal don't provide any trigger to open it. Where's an example of how to create a button to open modal.
+By default, modal doesn't provide any trigger to open it. Here's an example of how to create a button to open a modal.
 
 <div class="example example-code">
   <button class="button button-primary" data-trigger>Open Modal</button>
@@ -110,7 +110,7 @@ trigger.on('click', () => {
 
 Once you called `show()`, `modal()` bind the close icon and `esc` keyboard key to hide modal.
 
-To have a default open and close button, you can use `triggerOpen` and `triggerClose` and modal will delegate `click` event to these selector and call `show()` or `hide()` when click is fired. Example:
+ In order to have a default open and close button, you can use `triggerOpen` and `triggerClose`, the  modal will delegate `click` event to those selectors and call `show()` or `hide()` when the click event is fired. Example:
 
 ```js
 $('[data-modal]').modal({
@@ -121,7 +121,7 @@ $('[data-modal]').modal({
 
 ## Set Modal size
 
-The modal has three predefined sizes that can be chosen, small, medium or large.
+The modal has three predefined sizes: small, medium, or large.
 
 <div class="example example-code align-center">
   <button class="button button-primary" data-trigger-small="open">Open Small Modal</button>

--- a/docs/js/modal.md
+++ b/docs/js/modal.md
@@ -51,7 +51,7 @@ Modal provides some customizable options as: `container`, `size`, `triggerClose`
 | Option            | Default | Description |
 |-------------------|-------------|
 | container  | `"body"` | A new string selector to append `.modal` |
-| size | `"medium"` | Size of the modal, can be "small", "large" or "medium" |
+| size | `"medium"` | Modal sizes that can be "small", "large" or "medium" |
 | triggerClose | `null` | A string selector to bind and call hide method when clicked |
 | triggerOpen | `null` | A string selector to bind and call show method when clicked |
 | static | false | When false insert the close icon and call hide method when clicked outside modal  |
@@ -87,57 +87,41 @@ new Modal(document.querySelectorAll('[data-modal]'), options);
 
 By default, modal don't provide any trigger to open it. Where's an example of how to create a button to open modal.
 
-```html
-<button data-trigger>Open Modal</button>
-```
+<div class="example example-code">
+  <button class="button button-primary" data-trigger>Open Modal</button>
+</div>
 
 ```js
-let modal = $('[data-modal]').modal(),
-    trigger = $('[data-trigger]');
+let modal = $('[data-modal-trigger]').modal().data('modal')
+let trigger = $('[data-trigger]');
 
 trigger.on('click', () => {
   modal.show();
 });
 ```
+<div data-modal-trigger class="hide">
+  <div class="row">
+    <div class="col-xs-12">
+      <h2>Trigger Modal example</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </div>
+  </div>
+</div>
+
 Once you called `show()`, `modal()` bind the close icon and `esc` keyboard key to hide modal.
 
-If you want that a button inside `.modal` close itself, add option `triggerClose` with a string selector. Modal will delegate `click` to selector and call `hide()` when click is fired.
+To have a default open and close button, you can use `triggerOpen` and `triggerClose` and modal will delegate `click` event to these selector and call `show()` or `hide()` when click is fired. Example:
 
 ```js
-let modal = $('[data-modal]').modal({
-      triggerClose: '.any-selector',
-      triggerOpen: '[data-trigger="open"]'
-    })
+$('[data-modal]').modal({
+  triggerClose: '.any-selector',
+  triggerOpen: '[data-trigger="open"]'
+})
 ```
 
-## How to set the modal size
+## Set Modal size
 
 The modal has three predefined sizes that can be chosen, small, medium or large.
-
-```js
-//small
-let options = {
-  size: 'small'
-}
-
-//medium
-let options = {
-  size: 'medium'
-}
-
-//large
-let options = {
-  size: 'large'
-}
-
-// as a jquery plugin
-$('[data-modal]').modal(options);
-
-// as a vanilla constructor
-new Modal(document.querySelectorAll('[data-modal]'), options);
-```
-
-### Working buttons examples
 
 <div class="example example-code align-center">
   <button class="button button-primary" data-trigger-small="open">Open Small Modal</button>
@@ -145,12 +129,15 @@ new Modal(document.querySelectorAll('[data-modal]'), options);
   <button class="button button-primary" data-trigger-large="open">Open Large Modal</button>
 </div>
 
+```js
+$('[data-modal]').modal({ size: 'small|medium|large' });
+```
+
 <div data-modal-small class="hide">
   <div class="row">
     <div class="col-xs-12">
-      <h2>hello</h2>
+      <h2>Small size example</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-      <button class="button button-primary" data-trigger="close">Close</button>
     </div>
   </div>
 </div>
@@ -158,9 +145,8 @@ new Modal(document.querySelectorAll('[data-modal]'), options);
 <div data-modal-medium class="hide">
   <div class="row">
     <div class="col-xs-12">
-      <h2>hello</h2>
+      <h2>Medium size example</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-      <button class="button button-primary" data-trigger="close">Close</button>
     </div>
   </div>
 </div>
@@ -168,9 +154,8 @@ new Modal(document.querySelectorAll('[data-modal]'), options);
 <div data-modal-large class="hide">
   <div class="row">
     <div class="col-xs-12">
-      <h2>hello</h2>
+      <h2>Large size example</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-      <button class="button button-primary" data-trigger="close">Close</button>
     </div>
   </div>
 </div>
@@ -181,9 +166,26 @@ It's possible to use a modal in cases where a user interaction is mandatory befo
 With the `static` and `keyboard` options, you can turn off the options to close the modal.
 You need to call the `.hide()` function manually.
 
+<div class="example example-code">
+  <button class="button button-primary" data-trigger-static="open">Open Static Modal</button>
+</div>
+
 ```js
-let modal = $('[data-modal]').modal({
-      static: true,
-      keyboard: false
-    })
+let modalStatic = $('[data-modal-static]').modal({
+  static: true,
+  keyboard: false
+}).data('modal')
+
+function closeModalStatic() {
+  modalStatic.hide()
+}
 ```
+
+<div data-modal-static class="hide">
+  <div class="row">
+    <div class="col-xs-12">
+      <h2>Static Modal example</h2>
+      <p>Lorem ipsum dolor sit amet, you know how to close it, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </div>
+  </div>
+</div>

--- a/docs/js/modal.md
+++ b/docs/js/modal.md
@@ -12,7 +12,7 @@ path: modal
 
 ## How to
 
-Modal component allow users to choose which selector to use, you can use a simple `[data-whatever]` or a class. Be sure to not use class like: `.modal`, `.modal-content`, `.modal-body` to initiate modal.
+Modal component allow users to choose which selector to use, you can use a simple `[data-whatever]` or a class. Be sure to not use class like: `.modal`, `.modal-content`, `.modal-body` to initiate modal. Modal has variable `height` based on his content and the `max-height` is `90%`.
 
 You can initiate as a jQuery plugin:
 

--- a/docs/layout/page.jade
+++ b/docs/layout/page.jade
@@ -54,23 +54,43 @@ html(lang="pt-BR")
       });
 
       $('.docs').form();
-      
-      var smallModal = $('[data-modal-small]').modal({
+
+      $('[data-modal]').modal({
         triggerClose: '[data-trigger="close"]',
+        triggerOpen: '[data-trigger="open"]'
+      });
+
+      $('[data-modal-small]').modal({
         triggerOpen: '[data-trigger-small="open"]',
         size: 'small'
       });
-      
-      var mediumModal = $('[data-modal-medium]').modal({
-        triggerClose: '[data-trigger="close"]',
+
+      $('[data-modal-medium]').modal({
         triggerOpen: '[data-trigger-medium="open"]',
         size: 'medium'
       });
-      
-      var largeModal = $('[data-modal-large]').modal({
-        triggerClose: '[data-trigger="close"]',
+
+      $('[data-modal-large]').modal({
         triggerOpen: '[data-trigger-large="open"]',
         size: 'large'
+      });
+
+      let modalStatic = $('[data-modal-static]').modal({
+        triggerOpen: '[data-trigger-static="open"]',
+        static: true,
+        keyboard: false
+      }).data('modal');
+
+      function closeModalStatic() {
+        console.log('you did it! :)')
+        return modalStatic.hide()
+      }
+
+      let modalTrigger = $('[data-modal-trigger]').modal().data('modal')
+      let trigger = $('[data-trigger]');
+
+      trigger.on('click', function() {
+        modalTrigger.show();
       });
 
       $('[data-notification-dynamic]').notification({

--- a/docs/layout/page.jade
+++ b/docs/layout/page.jade
@@ -54,10 +54,23 @@ html(lang="pt-BR")
       });
 
       $('.docs').form();
-
-      var modal = $('[data-modal]').modal({
+      
+      var smallModal = $('[data-modal-small]').modal({
         triggerClose: '[data-trigger="close"]',
-        triggerOpen: '[data-trigger="open"]'
+        triggerOpen: '[data-trigger-small="open"]',
+        size: 'small'
+      });
+      
+      var mediumModal = $('[data-modal-medium]').modal({
+        triggerClose: '[data-trigger="close"]',
+        triggerOpen: '[data-trigger-medium="open"]',
+        size: 'medium'
+      });
+      
+      var largeModal = $('[data-modal-large]').modal({
+        triggerClose: '[data-trigger="close"]',
+        triggerOpen: '[data-trigger-large="open"]',
+        size: 'large'
       });
 
       $('[data-notification-dynamic]').notification({

--- a/docs/layout/page.jade
+++ b/docs/layout/page.jade
@@ -82,8 +82,7 @@ html(lang="pt-BR")
       }).data('modal');
 
       function closeModalStatic() {
-        console.log('you did it! :)')
-        return modalStatic.hide()
+        return modalStatic.hide();
       }
 
       let modalTrigger = $('[data-modal-trigger]').modal().data('modal')

--- a/src/css/atoms/modal.css
+++ b/src/css/atoms/modal.css
@@ -5,30 +5,30 @@
   transition: opacity .3s ease-in-out;
   width: 100%;
   z-index: $index-foremost;
+}
 
-  &::before {
-    content: " ";
-    display: inline-block;
-    height: 100%;
-    position: relative;
-    vertical-align: middle;
-  }
+.modal::before {
+  content: "";
+  display: inline-block;
+  height: 100%;
+  position: relative;
+  vertical-align: middle;
+}
 
-  &-enter {
-    left: 0;
-    position: fixed;
-    top: 0;
-  }
+.modal-enter {
+  left: 0;
+  position: fixed;
+  top: 0;
+}
 
-  &-show {
-    opacity: 1;
-  }
+.modal-show {
+  opacity: 1;
+}
 
-  &-leave {
-    opacity: 0;
-  }
+.modal-leave {
+  opacity: 0;
+}
 
-  &-hide {
-    position: static;
-  }
+.modal-hide {
+  position: static;
 }

--- a/src/css/atoms/modal/content.css
+++ b/src/css/atoms/modal/content.css
@@ -17,38 +17,58 @@
   transition: transform .3s ease, opacity .3s ease;
   vertical-align: middle;
   width: 95%;
+}
 
-  &-enter {
-    display: inline-block;
-  }
+.modal-content-enter {
+  display: inline-block;
+}
 
-  &-show {
-    opacity: 1;
-    transform: scale(1);
-  }
+.modal-content-show {
+  opacity: 1;
+  transform: scale(1);
+}
 
-  &-leave {
-    opacity: 0;
-    transform: scale(1.3);
-  }
+.modal-content-leave {
+  opacity: 0;
+  transform: scale(1.3);
+}
 
-  &-hide {
-    display: none;
-  }
+.modal-content-hide {
+  display: none;
 }
 
 @media (--medium) {
 
-  .modal-content {
+  .modal-content-lg {
+    margin-left: -37.5%;
+    width: 75%;
+  }
+
+  .modal-content-md {
     margin-left: -32.5%;
     width: 65%;
+  }
+
+  .modal-content-sm {
+    margin-left: -27.5%;
+    width: 55%;
   }
 }
 
 @media (--large) {
 
-  .modal-content {
+  .modal-content-lg {
+    margin-left: -30%;
+    width: 60%;
+  }
+
+  .modal-content-md {
     margin-left: -25%;
     width: 50%;
+  }
+
+  .modal-content-sm {
+    margin-left: -20%;
+    width: 40%;
   }
 }

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -11,6 +11,7 @@ const templates = {
 
 const DEFAULTS = {
   container: 'body',
+  size: 'medium',
   triggerClose: null,
   static: false,
   keyboard: true,
@@ -141,6 +142,8 @@ class Modal {
     this.$content = $(templates.content)
     this.$close = $(templates.close)
 
+    this.$content.addClass(this.setupSizeModal(this.options.size))
+
     if (!this.isStaticModal()) {
       this.$content.append(this.$close)
     }
@@ -155,6 +158,16 @@ class Modal {
 
   isStaticModal () {
     return this.options.static
+  }
+
+  setupSizeModal (size) {
+    var sizes = {
+      'small': 'modal-content-sm',
+      'medium': 'modal-content-md',
+      'large': 'modal-content-lg'
+    }
+
+    return sizes[size]
   }
 }
 

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -438,6 +438,14 @@ describe('Modal spec', () => {
       expect(instance.$close).to.not.be.undefined
     })
 
+    it('should add the size class to $content', () => {
+      const size = instance.setupSizeModal(instance.options.size)
+
+      instance.createModal()
+
+      expect(instance.$content.hasClass(size)).to.be.true
+    })
+
     it('should append $close in $content', () => {
       instance.createModal()
 
@@ -497,6 +505,34 @@ describe('Modal spec', () => {
         instance.options.static = false
 
         expect(instance.isStaticModal()).to.be.false
+      })
+    })
+  })
+
+  describe('setupSizeModal', () => {
+    context('when the size is small', () => {
+      it('should return the modal-content-sm class ', () => {
+        instance.options.size = 'small'
+        const classSize = instance.setupSizeModal(instance.options.size)
+
+        expect(classSize).to.be.equal('modal-content-sm')
+      })
+    })
+
+    context('when the size is medium', () => {
+      it('should return the modal-content-md class ', () => {
+        const classSize = instance.setupSizeModal(instance.options.size)
+
+        expect(classSize).to.be.equal('modal-content-md')
+      })
+    })
+
+    context('when the size is large', () => {
+      it('should return the modal-content-lg class ', () => {
+        instance.options.size = 'large'
+        const classSize = instance.setupSizeModal(instance.options.size)
+
+        expect(classSize).to.be.equal('modal-content-lg')
       })
     })
   })


### PR DESCRIPTION
Add a size option to modal component, with three possibilities: small, medium(default value) and large.

Doc: 
![image](https://cloud.githubusercontent.com/assets/17216397/21939346/84a3c3b0-d9a6-11e6-950c-0600adfb6c06.png)