### PR TITLE
feat(tooltip): Register the Popper instance on the tooltip element

### DIFF
--- a/src/js/components/tooltip.js
+++ b/src/js/components/tooltip.js
@@ -16,7 +16,7 @@ class Tooltip {
   }
 
   init () {
-    this._buildPopper()
+    this._registerPopper()
 
     return this
   }
@@ -28,6 +28,12 @@ class Tooltip {
 
   _buildPopper () {
     return new Popper(this.$element[0], this.$target[0], this.options)
+  }
+
+  _registerPopper () {
+    const popper = this._buildPopper()
+
+    this.$element.data('popper', popper)
   }
 }
 

--- a/test/components/tooltip.spec.js
+++ b/test/components/tooltip.spec.js
@@ -19,11 +19,15 @@ describe('Tooltip spec', () => {
   })
 
   describe('init', () => {
-    it('should return the instance itself', sinon.test(function () {
-      const stub = this.stub(instance, '_buildPopper')
+    it('should return the instance itself', () => {
+      expect(instance.init()).to.be.equal(instance)
+    })
+
+    it('should register the popper instance on the element', () => {
       instance.init()
-      expect(stub.calledOnce).to.be.true
-    }))
+
+      expect(instance.$element.data('popper')).to.be.an.instanceof(Popper)
+    })
   })
 
   describe('_getTarget', () => {


### PR DESCRIPTION
It is impossible, from the outside, to call a method on the popper instance itself, such as `update`, `destroy` and so on. This PR will store the instance in a data-attribute on the tooltip element, so we can access it using `$tooltip.data('popper')`.