### PR TITLE
fix(select): added appearance none to .select inputs

### DIFF
--- a/docs/css/form.md
+++ b/docs/css/form.md
@@ -59,18 +59,23 @@ Tag `<textarea>` is not styled by default. You must use `.textarea` in order to 
 Tag `<select>` is not styled by default. You must use the `.select` in order to style it.
 
 <div class="example example-code">
-  <select class="select">
-    <option>Select your option</option>
-    <option value="option-1">Option 1</option>
-    <option value="option-2">Option 2</option>
-    <option value="option-3">Option 3</option>
-  </select>
+  <div class="field field-select">
+    <select class="select">
+      <option></option>
+      <option value="option-1">Option 1</option>
+      <option value="option-2">Option 2</option>
+      <option value="option-3">Option 3</option>
+    </select>
+    <label class="label">Select your option</label>
+  </div>
 </div>
 
 ```html
-<select class="select">
-  <option></option>
-</select>
+<div class="field field-select">
+  <select class="select">
+    <option></option>
+  </select>
+</div>
 ```
 
 ### Helper
@@ -111,7 +116,7 @@ _**Obs:** When using `.helper`, don't forget to add `aria-describedby` indicate 
 ```
 
 <div class="example example-code">
-  <div class="field">
+  <div class="field field-select">
     <select class="select" name="select" id="select">
       <option> </option>
       <option>option</option>
@@ -122,7 +127,7 @@ _**Obs:** When using `.helper`, don't forget to add `aria-describedby` indicate 
 </div>
 
 ```html
-<div class="field">
+<div class="field field-select">
   <select class="select">
     <option></option>
   </select>

--- a/src/css/atoms/form/select.css
+++ b/src/css/atoms/form/select.css
@@ -1,5 +1,6 @@
 .select {
   @mixin form-component default, primary-dark {
+    appearance: none;
     background-color: $color-neutral;
     font-size: 1.1rem;
     height: 2.5rem;

--- a/src/css/molecules/field.css
+++ b/src/css/molecules/field.css
@@ -3,7 +3,20 @@
   &-select {
 
     &::after {
-      right: 1.56rem;
+      right: 1.8rem;
+      top: 1.2rem;
+    }
+
+    &::before {
+      border-left: .35rem solid transparent;
+      border-right: .35rem solid transparent;
+      border-top: .35rem solid $color-black;
+      content: "";
+      height: 0;
+      position: absolute;
+      right: .6rem;
+      top: 1.6rem;
+      width: 0;
     }
   }
 


### PR DESCRIPTION
This PR add `appearance: none` to `.select` inputs, for all devices render a default design.

Before:
![image](https://cloud.githubusercontent.com/assets/1045308/23279220/27e93c50-f9f3-11e6-9ead-759d00378b04.png)


After:
![image](https://cloud.githubusercontent.com/assets/1045308/23279754/37625eb2-f9f5-11e6-86df-129c3550c4ba.png)

![image](https://cloud.githubusercontent.com/assets/1045308/23279870/c19909b4-f9f5-11e6-8cda-2c3e8f129054.png)

