### PR TITLE
fix(forms): Update select arrows to not overlap option text

### DIFF
--- a/src/css/molecules/field.css
+++ b/src/css/molecules/field.css
@@ -2,6 +2,10 @@
 
   &-select {
 
+    .select {
+      padding-right: 1.5rem;
+    }
+
     &::after {
       right: 1.8rem;
       top: 1.2rem;


### PR DESCRIPTION
When the text on the `option` tag is big, the arrow was overlapping it.

# Preview

### Before
![screenshot from 2017-03-08 11-27-09](https://cloud.githubusercontent.com/assets/5838414/23707853/a20b3732-03f2-11e7-83f5-409ff9803aed.png)

### After
![screenshot from 2017-03-08 11-27-39](https://cloud.githubusercontent.com/assets/5838414/23707868/ae8cb698-03f2-11e7-8fe9-310ecb45dff0.png)