### PR TITLE
feat(confirm): Add Confirm component

### DIFF
--- a/docs/components/confirm.md
+++ b/docs/components/confirm.md
@@ -1,0 +1,88 @@
+---
+title: Confirm
+layout: page.jade
+sidebar: true
+collection: docs
+priority: 3
+path: confirm
+section: js
+---
+
+# Confirm
+<p class="lead">
+  A confirm is used to present a question message to users' actions.
+</p>
+
+## Summary
+1. [Usage](#usage)
+2. [Options](#options)
+3. [Size option](#size-option)
+
+
+## Usage
+The confirm component is an empty container where you can add a message that will be presented to users so they can confirm or not the execution of an specific action.
+
+You can initiate the component as a jQuery plugin:
+```js
+// using any selector
+$('any-selector').on('click', () => $.fn.confirm(callback, options));
+```
+
+Or as a vanilla constructor:
+
+```js
+import Confirm from 'garden/src/js/components/confirm';
+
+new Confirm(callback, options);
+```
+
+The component takes a callback in the first argument and the options in the second argument.
+
+Here's an example on how to create a button to open a confirm window.
+
+<div class="example example-code">
+  <button class="button button-primary" data-confirm>Open Confirm</button>
+</div>
+
+### Options
+
+These are the options provided with the confirm component, along with their default values.
+
+| Option            | Default | Description |
+|-------------------|-------------|
+| textMessage  | `This is an example message` | A text to display in the confirm |
+| textConfirmButton | `Ok` | A text to the confirm button |
+| textCancelButton | `Cancel` | A text to the cancel button |
+| size | `"medium"` | The modal size may vary between small, large, or medium |
+
+Below is an example on how to initialize the component passing customized options.
+```js
+let options = {
+  textMessage: 'This is an example message',
+  textConfirmButton: 'Ok',
+  textCancelButton: 'Cancel'
+}
+
+const callback = (value) => value
+
+// as a jquery plugin
+$('[data-confirm]').on('click', () => $.fn.confirm(callback, options));
+
+// as a vanilla constructor
+new Confirm(callback, options);
+```
+
+### Size option
+
+As stated, a confirm has three predefined sizes: small, medium, or large.
+You can click on the buttons below to check each size option.
+
+<div class="example example-code align-center">
+  <button class="button button-primary" data-confirm-small>Open Small Confirm</button>
+  <button class="button button-primary" data-confirm-medium>Open Medium Confirm</button>
+  <button class="button button-primary" data-confirm-large>Open Large Confirm</button>
+</div>
+
+```js
+$('[data-confirm]').on('click', () => $.fn.confirm((value) => value, { size: 'small|medium|large' }));
+```

--- a/docs/components/confirm.md
+++ b/docs/components/confirm.md
@@ -10,7 +10,7 @@ section: js
 
 # Confirm
 <p class="lead">
-  A confirm is used to present a question message to users' actions.
+  A confirm is used to present confirmation messages according to users' actions.
 </p>
 
 ## Summary

--- a/docs/layout/page.jade
+++ b/docs/layout/page.jade
@@ -24,15 +24,15 @@ html(lang="pt-BR")
           .col-xs-12.col-sm-4.col-md-3
             - const css = collections[collection].filter((page) => page.section === 'css')
             - const js = collections[collection].filter((page) => page.section === 'js')
-            
+
             h4.heading-4 CSS
-                        
+
             nav.sidebar
               each page in css
                 a.link(href="#{page.path}.html", class=title === page.title ? "link-active" : undefined) #{page.title}
-            
+
             h4.heading-4 JS
-            
+
             nav.sidebar
               each page in js
                 a.link(href="#{page.path}.html", class=title === page.title ? "link-active" : undefined) #{page.title}
@@ -103,24 +103,24 @@ html(lang="pt-BR")
       trigger.on('click', function() {
         modalTrigger.show();
       });
-      
+
       $('[data-alert]').on('click', () => $.fn.alert());
 
       $('[data-alert-small]').on('click', () => $.fn.alert({
         textMessage: 'Small alert example message',
         size: 'small'
       }));
-      
+
       $('[data-alert-medium]').on('click', () => $.fn.alert({
         textMessage: 'Medium alert example message',
         size: 'medium'
       }));
-      
+
       $('[data-alert-large]').on('click', () => $.fn.alert({
         textMessage: 'Large alert example message',
         size: 'large'
       }));
-      
+
       $('[data-notification-temp-button]').on('click', () => {
         const notificationContainer = $('[data-notification-temporary]')
         const notification = notificationContainer.find('.notification')
@@ -135,6 +135,23 @@ html(lang="pt-BR")
           hideIn: 2000
         });
       });
+
+      $('[data-confirm]').on('click', () => $.fn.confirm((value) => value));
+
+      $('[data-confirm-small]').on('click', () => $.fn.confirm((value) => value, {
+        textMessage: 'Small confirm example message',
+        size: 'small'
+      }));
+
+      $('[data-confirm-medium]').on('click', () => $.fn.confirm((value) => value, {
+        textMessage: 'Medium confirm example message',
+        size: 'medium'
+      }));
+
+      $('[data-confirm-large]').on('click', () => $.fn.confirm((value) => value, {
+        textMessage: 'Large confirm example message',
+        size: 'large'
+      }));
 
       $('[data-notification-dynamic]').notification({
         message: 'This is a dynamic notification.',

--- a/src/js/components/confirm.js
+++ b/src/js/components/confirm.js
@@ -1,0 +1,98 @@
+import $ from 'jquery'
+import Modal from './modal'
+
+const NAME = 'confirm'
+
+const DEFAULTS = {
+  textMessage: 'This is an example message',
+  textConfirmButton: 'Ok',
+  textCancelButton: 'Cancel',
+  size: 'medium',
+  static: true,
+  triggerCancel: '[data-cancel-button]',
+  triggerConfirm: '[data-confirm-button]'
+}
+
+class Confirm {
+  constructor (callback, options = {}) {
+    this.options = $.extend({}, DEFAULTS, options)
+    this.callback = callback
+  }
+
+  init () {
+    this.setupConfirm()
+    this.setupElements()
+    this.bindListeners()
+    this.showConfirm()
+  }
+
+  setupConfirm () {
+    this.$element = $(this.buildHtml(this.options))
+
+    this.modal = this.$element.modal(this.options).data('modal')
+  }
+
+  setupElements () {
+    const { $content } = this.modal
+    this.$confirmButton = $content.find(this.options.triggerConfirm)
+    this.$cancelButton = $content.find(this.options.triggerCancel)
+  }
+
+  bindListeners () {
+    this.$confirmButton.on('click', this.onConfirmClick.bind(this))
+    this.$cancelButton.on('click', this.onCancelClick.bind(this))
+  }
+
+  onConfirmClick () {
+    this.callback(true)
+    this.hideConfirm()
+  }
+
+  onCancelClick () {
+    this.callback(false)
+    this.hideConfirm()
+  }
+
+  showConfirm () {
+    this.modal.show()
+  }
+
+  hideConfirm () {
+    this.modal.hide()
+  }
+
+  buildHtml ({ textMessage, textConfirmButton, textCancelButton }) {
+    return (`
+      <div>
+        <div class="container-fluid align-center">
+          <div class="row">
+            <div class="col-xs-12">
+              <p data-confirm-text>${textMessage}</p>
+            </div>
+            <div class="row">
+              <div class="col-xs-offset-2 col-xs-5 col-md-4">
+                <button class="button button-primary button-full" data-confirm-button>
+                  ${textConfirmButton}
+                </button>
+              </div>
+              <div class="col-xs-5 col-md-4">
+                <button class="button button-full" data-cancel-button>
+                  ${textCancelButton}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `)
+  }
+}
+
+/* istanbul ignore next */
+$.fn[NAME] = function (callback, options) {
+  return $.data(this, NAME, new Confirm(callback, options).init())
+}
+
+/* istanbul ignore next */
+export default (callback, options) => new Confirm(callback, options).init()
+export { Confirm }

--- a/test/components/confirm.spec.js
+++ b/test/components/confirm.spec.js
@@ -1,0 +1,202 @@
+import $ from 'jquery'
+import { Confirm } from '../../src/js/components/confirm'
+
+describe('Confirm component', () => {
+  let instance
+
+  beforeEach(() => {
+    instance = new Confirm(() => {})
+  })
+
+  describe('@init', () => {
+    it('should call @setupConfirm', sinon.test(function () {
+      const stub = this.stub(instance, 'setupConfirm')
+      this.stub(instance, 'setupElements')
+      this.stub(instance, 'bindListeners')
+      this.stub(instance, 'showConfirm')
+
+      instance.init()
+
+      expect(stub.calledOnce).to.be.true
+    }))
+
+    it('should call @setupElements', sinon.test(function () {
+      const stub = this.stub(instance, 'setupElements')
+      this.stub(instance, 'setupConfirm')
+      this.stub(instance, 'bindListeners')
+      this.stub(instance, 'showConfirm')
+
+      instance.init()
+
+      expect(stub.calledOnce).to.be.true
+    }))
+
+    it('should call @bindListeners', sinon.test(function () {
+      const stub = this.stub(instance, 'bindListeners')
+      this.stub(instance, 'setupConfirm')
+      this.stub(instance, 'setupElements')
+      this.stub(instance, 'showConfirm')
+
+      instance.init()
+
+      expect(stub.calledOnce).to.be.true
+    }))
+
+    it('should call @showConfirm', sinon.test(function () {
+      const stub = this.stub(instance, 'showConfirm')
+      this.stub(instance, 'setupConfirm')
+      this.stub(instance, 'setupElements')
+      this.stub(instance, 'bindListeners')
+
+      instance.init()
+
+      expect(stub.calledOnce).to.be.true
+    }))
+  })
+
+  describe('@setupConfirm', () => {
+    it('should properly assign $element', () => {
+      instance.$element = undefined
+
+      instance.setupConfirm()
+
+      expect(instance.$element).to.exist
+    })
+
+    it('should properly assign modal', () => {
+      instance.modal = undefined
+
+      instance.setupConfirm()
+
+      expect(instance.modal).to.exist
+    })
+  })
+
+  describe('setupElements', () => {
+    beforeEach(() => {
+      instance.setupConfirm()
+    })
+
+    it('should properly assign $confirmButton', () => {
+      instance.$confirmButton = undefined
+
+      instance.setupElements()
+
+      expect(instance.$confirmButton).to.exist
+    })
+
+    it('should properly assign $cancelButton', () => {
+      instance.$cancelButton = undefined
+
+      instance.setupElements()
+
+      expect(instance.$cancelButton).to.exist
+    })
+  })
+
+  describe('bindListeners', () => {
+    beforeEach(() => {
+      instance.setupConfirm()
+      instance.setupElements()
+    })
+
+    it('should bind @onConfirmClick as a handler to $confirmButton click event', sinon.test(function() {
+      const stub = this.stub(instance, 'onConfirmClick')
+
+      instance.bindListeners()
+      instance.$confirmButton.trigger('click')
+
+      expect(stub.calledOnce).to.be.true
+    }))
+
+    it('should bind @onCancelClick as a handler to $cancelButton click event', sinon.test(function() {
+      const stub = this.stub(instance, 'onCancelClick')
+
+      instance.bindListeners()
+      instance.$cancelButton.trigger('click')
+
+      expect(stub.calledOnce).to.be.true
+    }))
+  })
+
+  describe('@onConfirmClick', () => {
+    it('should properly call the callback', sinon.test(function () {
+      const stub = this.stub(instance, 'callback')
+      this.stub(instance, 'hideConfirm')
+
+      instance.onConfirmClick()
+
+      expect(stub.calledWith(true)).to.be.true
+    }))
+
+    it('should call @hideConfirm', sinon.test(function () {
+      const stub = this.stub(instance, 'hideConfirm')
+      this.stub(instance, 'callback')
+
+      instance.onConfirmClick()
+
+      expect(stub.calledOnce).to.be.true
+    }))
+  })
+  describe('@onCancelClick', () => {
+    it('should properly call the callback', sinon.test(function () {
+      const stub = this.stub(instance, 'callback')
+      this.stub(instance, 'hideConfirm')
+
+      instance.onCancelClick()
+
+      expect(stub.calledWith(false)).to.be.true
+    }))
+
+    it('should call @hideConfirm', sinon.test(function () {
+      const stub = this.stub(instance, 'hideConfirm')
+      this.stub(instance, 'callback')
+
+      instance.onCancelClick()
+
+      expect(stub.calledOnce).to.be.true
+    }))
+  })
+
+  describe('@showConfirm', () => {
+    it('should show the confirm component', sinon.test(function () {
+      instance.modal = { show () {} }
+      const stub = this.stub(instance.modal, 'show')
+
+      instance.showConfirm()
+
+      expect(stub.calledOnce).to.be.true
+    }))
+  })
+
+  describe('@hideConfirm', () => {
+    it('should hide the confirm component', sinon.test(function () {
+      instance.modal = { hide () {} }
+      const stub = this.stub(instance.modal, 'hide')
+
+      instance.hideConfirm()
+
+      expect(stub.calledOnce).to.be.true
+    }))
+  })
+
+  describe('@buildHtml', () => {
+    it('should have the data-confirm-text attribute', () => {
+      const html = instance.buildHtml('string', 'string')
+
+      expect($(html).find('[data-confirm-text]')).to.exist
+    })
+
+    it('should have the data-confirm-button attribute', () => {
+      const html = instance.buildHtml('string', 'string')
+
+      expect($(html).find('[data-confirm-button]')).to.exist
+    })
+
+    it('should have the data-cancel-button attribute', () => {
+      const html = instance.buildHtml('string', 'string')
+
+      expect($(html).find('[data-cancel-button]')).to.exist
+    })
+  })
+})


### PR DESCRIPTION
Add the Confirm component extends the actual modal component using JQuery plugin.

Confirm  receives a callback and provides some customizable options such as: textMessage, textConfirmButton, textCancelButton, and size.

![confirm](https://cloud.githubusercontent.com/assets/17216397/24263856/35e28816-0fdd-11e7-9e4b-8304f0946376.gif)
