### PR TITLE
feat(sidebar-labels): Remove prefixes from section names

### DIFF
--- a/docs/components/css-form.md
+++ b/docs/components/css-form.md
@@ -1,5 +1,5 @@
 ---
-title: CSS Form
+title: Form
 layout: page.jade
 sidebar: true
 collection: docs

--- a/docs/components/css-notifications.md
+++ b/docs/components/css-notifications.md
@@ -1,5 +1,5 @@
 ---
-title: CSS Notifications
+title: Notifications
 layout: page.jade
 sidebar: true
 collection: docs

--- a/docs/components/css-utilities.md
+++ b/docs/components/css-utilities.md
@@ -1,5 +1,5 @@
 ---
-title: CSS Utilities
+title: Utilities
 layout: page.jade
 sidebar: true
 collection: docs
@@ -8,7 +8,7 @@ path: css-utilities
 section: css
 ---
 
-# CSS Utilities
+# Utilities
 <p class="lead">
   Set of common classes and variables used to provide predefined style and measures.
 </p>

--- a/docs/components/js-form.md
+++ b/docs/components/js-form.md
@@ -1,5 +1,5 @@
 ---
-title: JS Form
+title: Form
 layout: page.jade
 sidebar: true
 collection: docs
@@ -8,7 +8,7 @@ path: js-form
 section: js
 ---
 
-# JS Form
+# Form
 <p class="lead">
   The form component is built as a jQuery plugin responsible for handling the state of input elements.
 </p>

--- a/docs/components/js-notifications.md
+++ b/docs/components/js-notifications.md
@@ -1,5 +1,5 @@
 ---
-title: JS Notifications
+title: Notifications
 layout: page.jade
 sidebar: true
 collection: docs
@@ -8,7 +8,7 @@ path: js-notifications
 section: js
 ---
 
-# JS Notifications
+# Notifications
 <p class="lead">
   This is an extension of the [notification atom](/components/css-notifications.html)
   and can be used to add some interactivity to notifications.

--- a/docs/components/js-utilities.md
+++ b/docs/components/js-utilities.md
@@ -1,5 +1,5 @@
 ---
-title: JS Utilities
+title: Utilities
 layout: page.jade
 sidebar: true
 collection: docs
@@ -8,7 +8,7 @@ path: js-utilities
 section: js
 ---
 
-# JS Utilities
+# Utilities
 <p class="lead">
   Set of utilities provided to help you write a better JavaScript code.
 </p>

--- a/docs/layout/page.jade
+++ b/docs/layout/page.jade
@@ -29,13 +29,15 @@ html(lang="pt-BR")
 
             nav.sidebar
               each page in css
-                a.link(href="#{page.path}.html", class=title === page.title ? "link-active" : undefined) #{page.title}
+                a.link(href="#{page.path}.html", class=title === page.title &&
+                  section === page.section ? "link-active" : undefined) #{page.title}
 
             h4.heading-4 JS
 
             nav.sidebar
               each page in js
-                a.link(href="#{page.path}.html", class=title === page.title ? "link-active" : undefined) #{page.title}
+                a.link(href="#{page.path}.html", class=title === page.title &&
+                  section === page.section ? "link-active" : undefined) #{page.title}
         if sidebar
           .col-xs-12.col-sm-8.col-md-9.content!= contents
         else


### PR DESCRIPTION
Change `page` layout to apply `link-active` class according to section of the current page as well.

The image below shows all the sections without the unnecessary prefixes `CSS` or `JS`.
![5270424280891392](https://cloud.githubusercontent.com/assets/6568078/25101706/9d70e614-238b-11e7-9115-b932d9e26f19.png)

 