### PR TITLE
fix(jump.js): add default options to jump and extends from util option

### DIFF
--- a/src/js/utils/scroll.js
+++ b/src/js/utils/scroll.js
@@ -5,8 +5,8 @@ import $ from 'jquery'
 import Jump from 'jump.js'
 
 const DEFAULTS = {
-	duration: 500,
-	offset: -30
+  duration: 500,
+  offset: -30
 }
 
 /**

--- a/src/js/utils/scroll.js
+++ b/src/js/utils/scroll.js
@@ -4,6 +4,11 @@
 import $ from 'jquery'
 import Jump from 'jump.js'
 
+const DEFAULTS = {
+	duration: 500,
+	offset: -30
+}
+
 /**
  * Default scroll method
  * @param  {element} el      The element to scroll to. Accepts both vanilla and $ selector
@@ -12,6 +17,6 @@ import Jump from 'jump.js'
 export default (el, options) => {
   return new Jump(
     el instanceof $ ? el[0] : el,
-    options
+    $.extend({}, DEFAULTS, options)
   )
 }


### PR DESCRIPTION
In order to add options to `jump.js` util, add `DEFAULTS` const with base `jumpjs` config and extend to a custom config.