### PR TITLE
fix(popper.js): pass placement options to constructor

### DIFF
--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -20,9 +20,30 @@ To create a tooltip, you need to add the `[data-tooltip]` attribute to the targe
 The selector used can either be a class name, a data attribute, or an ID, as in the example below.
 
 <div class="example example-code">
-  <div class="button" data-tooltip="#awesome-tooltip">
-    Button with tooltip
-    <div id="awesome-tooltip" class="tooltip">
+  <div class="button" data-tooltip="#top">
+    Tooltip on top
+    <div id="top" class="tooltip">
+      <strong>This is a basic tooltip</strong>
+    </div>
+  </div>
+
+  <div class="button" data-tooltip="#bottom">
+    Tooltip on bottom
+    <div id="bottom" class="tooltip">
+      <strong>This is a basic tooltip</strong>
+    </div>
+  </div>
+
+  <div class="button" data-tooltip="#left">
+    Tooltip on left
+    <div id="left" class="tooltip">
+      <strong>This is a basic tooltip</strong>
+    </div>
+  </div>
+
+  <div class="button" data-tooltip="#right">
+    Tooltip on right
+    <div id="right" class="tooltip">
       <strong>This is a basic tooltip</strong>
     </div>
   </div>

--- a/docs/layout/page.jade
+++ b/docs/layout/page.jade
@@ -171,7 +171,10 @@ html(lang="pt-BR")
 
       $('.toggle').collapse();
 
-      $('[data-tooltip]').tooltip();
+      $('[data-tooltip="#top"]').tooltip();
+      $('[data-tooltip="#bottom"]').tooltip({ placement: 'bottom' });
+      $('[data-tooltip="#left"]').tooltip({ placement: 'left' });
+      $('[data-tooltip="#right"]').tooltip({ placement: 'right' });
 
       $('[data-toggle-container]').on('click', () => {
         const container = $('[data-container]')

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "jump.js": "^1.0.2",
     "normalize.css": "^4.2.0",
-    "popper.js": "^0.5.1"
+    "popper.js": "^1.9.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.2.3",

--- a/src/js/components/tooltip.js
+++ b/src/js/components/tooltip.js
@@ -43,7 +43,7 @@ $.fn[NAME] = function (options) {
 
   return this.each(function () {
     if (!$.data(this, NAME)) {
-      $.data(this, NAME, new Tooltip(this, $(this).data()).init())
+      $.data(this, NAME, new Tooltip(this, options).init())
     }
   })
 }


### PR DESCRIPTION
Update Popper.js version and fix tooltip placement bug by adjusting options passed to component constructor.

## Preview
![popper](https://user-images.githubusercontent.com/6568078/26851879-a49f64c8-4ae2-11e7-8116-dd42ae5c23d4.gif)

