### PR TITLE
chore(sinon-test): create instance of sinon.test for tests

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -4,3 +4,4 @@ javascript:
 eslint:
   enabled: true
   config_file: .eslintrc
+  ignore_file: .eslintignore

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "postcss-simple-vars": "^3.0.0",
     "prismjs": "^1.3.0",
     "run-sequence": "^1.1.5",
-    "sinon": "^1.17.2",
+    "sinon": "^2.1.0",
+    "sinon-test": "^1.0.2",
     "stylelint": "^7.9.0",
     "stylelint-order": "^0.4.3",
     "webpack-stream": "^3.1.0",
@@ -104,8 +105,7 @@
   },
   "greenkeeper": {
     "ignore": [
-      "metalsmith-collections",
-      "sinon"
+      "metalsmith-collections"
     ]
   }
 }

--- a/test/entry.js
+++ b/test/entry.js
@@ -1,3 +1,8 @@
-var specs = require.context('.', true, /\.spec/);
+const specs = require.context('.', true, /\.spec/)
 
-specs.keys().forEach(specs);
+const sinonTest = require('sinon-test')
+sinon = require('sinon')
+
+sinon.test = sinonTest.configureTest(sinon)
+
+specs.keys().forEach(specs)


### PR DESCRIPTION
Make an instance of `sinon.test` available for all the tests. This was necessary due to the extraction of the `sinon.test` from the Sinon API.