### PR TITLE
fix(dialogs): Focus on the dialog buttons after displaying an alert or confirm

### DIFF
--- a/src/js/components/alert.js
+++ b/src/js/components/alert.js
@@ -28,7 +28,11 @@ class Alert {
   }
 
   showAlert () {
-    this.modal.show()
+    const { modal } = this
+    const { triggerClose } = this.options
+
+    modal.show()
+    modal.$content.find(triggerClose).focus()
   }
 
   hideAlert () {

--- a/src/js/components/confirm.js
+++ b/src/js/components/confirm.js
@@ -55,6 +55,7 @@ class Confirm {
 
   showConfirm () {
     this.modal.show()
+    this.$confirmButton.focus()
   }
 
   hideConfirm () {

--- a/test/components/alert.spec.js
+++ b/test/components/alert.spec.js
@@ -47,13 +47,29 @@ describe('Alert component', () => {
   })
 
   describe('@showAlert', () => {
+    beforeEach(() => {
+      instance.modal = {
+        show () {},
+        $content: $('<div><button data-alert-button>Ok</button></div>')
+      }
+    })
+
     it('should show the alert component', sinon.test(function () {
-      instance.modal = { show () {} }
       const stub = this.stub(instance.modal, 'show')
 
       instance.showAlert()
 
       expect(stub.calledOnce).to.be.true
+    }))
+
+    it('should focus on the alert button', sinon.test(function () {
+      const button = { focus () {} }
+      const spy = this.spy(button, 'focus')
+      this.stub(instance.modal.$content, 'find').returns(button)
+
+      instance.showAlert()
+
+      expect(spy.calledOnce).to.be.true
     }))
   })
 

--- a/test/components/confirm.spec.js
+++ b/test/components/confirm.spec.js
@@ -138,6 +138,7 @@ describe('Confirm component', () => {
       expect(stub.calledOnce).to.be.true
     }))
   })
+
   describe('@onCancelClick', () => {
     it('should properly call the callback', sinon.test(function () {
       const stub = this.stub(instance, 'callback')
@@ -159,13 +160,25 @@ describe('Confirm component', () => {
   })
 
   describe('@showConfirm', () => {
-    it('should show the confirm component', sinon.test(function () {
+    beforeEach(() => {
       instance.modal = { show () {} }
+      instance.$confirmButton = { focus () {} }
+    })
+
+    it('should show the confirm component', sinon.test(function () {
       const stub = this.stub(instance.modal, 'show')
 
       instance.showConfirm()
 
       expect(stub.calledOnce).to.be.true
+    }))
+
+    it('should focus on the confirm button', sinon.test(function () {
+      const spy = this.spy(instance.$confirmButton, 'focus')
+
+      instance.showConfirm()
+
+      expect(spy.calledOnce).to.be.true
     }))
   })
 


### PR DESCRIPTION
The focus was still placed on the element that triggered the dialog, causing the opening of multiple dialogs when hitting the `enter` key

# Alert

## Before
![peek 2017-06-22 11-38](https://user-images.githubusercontent.com/5838414/27440119-21969d66-5740-11e7-8532-eed3bf3505aa.gif)

## After
![peek 2017-06-22 11-40](https://user-images.githubusercontent.com/5838414/27440128-2b0d066e-5740-11e7-9802-2c92e6ac103a.gif)

# Confirm

## Before
![peek 2017-06-22 11-39](https://user-images.githubusercontent.com/5838414/27440146-3fdb6702-5740-11e7-93c9-c06ef64eb8d4.gif)

## After
![peek 2017-06-22 11-39_0](https://user-images.githubusercontent.com/5838414/27440153-44afe99c-5740-11e7-8537-4f6942eeda4f.gif)
