### PR TITLE
chore(lint): Add chai friendly eslint plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,8 @@
 {
   "rules": {
-    "no-unused-vars": 0
+    "no-unused-vars": 0,
+    "no-unused-expressions": 0,
+    "chai-friendly/no-unused-expressions": 2
   },
   "extends": "standard",
   "env": {
@@ -11,5 +13,8 @@
     "fixture": true,
     "sinon": true,
     "history": true
-  }
+  },
+  "plugins": [
+    "chai-friendly"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "del": "^3.0.0",
     "eslint": "^4.0.0",
     "eslint-config-standard": "^10.2.1",
+    "eslint-plugin-chai-friendly": "^0.3.6",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-node": "^5.0.0",
     "eslint-plugin-promise": "^3.5.0",


### PR DESCRIPTION
Due to the ESLint update, we're getting "no-unused-expressions" when writing Chai expectations. The [eslint-plugin-chai-friendly](https://github.com/ihordiachenko/eslint-plugin-chai-friendly) overrides the original rule to make it work.