### PR TITLE
fix(chai-friendly): adjust conditional operator in Collapse component

### DIFF
--- a/src/js/components/collapse.js
+++ b/src/js/components/collapse.js
@@ -44,7 +44,11 @@ class Collapse {
   }
 
   toggleTarget () {
-    this.isCollapsed ? this.showTarget() : this.hideTarget()
+    if (this.isCollapsed) {
+      this.showTarget()
+    } else {
+      this.hideTarget()
+    }
   }
 
   hideTarget () {


### PR DESCRIPTION
This fixes an error thrown by chai-friendly due to a conditional operator in the Collapse component.

![screenshot from 2017-06-26 13-36-23](https://user-images.githubusercontent.com/6568078/27550520-63f53044-5a76-11e7-9da9-92620df8e20e.png)

