### PR TITLE
Update syntax for stylelint rule

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -35,7 +35,7 @@
     "block-closing-brace-newline-before": "always",
     "selector-combinator-space-after": "always",
     "selector-combinator-space-before": "always",
-    "selector-no-id": true,
+    "selector-max-id": 0,
     "selector-no-vendor-prefix": true,
     "selector-pseudo-element-colon-notation": "double",
     "rule-empty-line-before": "always",


### PR DESCRIPTION
Fix warning thrown by stylelint on `selector-no-id` rule.


![screenshot from 2017-06-27 14-19-13](https://user-images.githubusercontent.com/6568078/27602955-e80cd376-5b4a-11e7-8aae-005baf0469d8.png)

