### PR TITLE
fix(field): add pointer-events none to select arrow

### DIFF
--- a/src/css/molecules/field.css
+++ b/src/css/molecules/field.css
@@ -17,6 +17,7 @@
       border-top: .35rem solid $color-black;
       content: "";
       height: 0;
+      pointer-events: none;
       position: absolute;
       right: .6rem;
       top: 1.6rem;


### PR DESCRIPTION
Update the select arrow to have point-events equals none at fields style.

## Before:

![select1](https://user-images.githubusercontent.com/17216397/27611614-43b21a2e-5b69-11e7-8054-e35036b32ae3.gif)

## After:

![select2](https://user-images.githubusercontent.com/17216397/27611627-4dd9a418-5b69-11e7-9f46-95f90272285d.gif)
