### PR TITLE
feat(pricetag): remove stripes from promotional modifier

### DIFF
--- a/src/css/molecules/pricetag.css
+++ b/src/css/molecules/pricetag.css
@@ -9,22 +9,8 @@
   border-radius: .25rem;
   color: $color-text-promotional;
   overflow: hidden;
-  padding-bottom: .7rem;
-  padding-left: .3125rem;
-  padding-right: .3125rem;
-  padding-top: .3125rem;
+  padding: .3125rem;
   position: relative;
-
-  &::after {
-    background-image: linear-gradient(-45deg, transparent 23%, $color-text-promotional 23%, $color-text-promotional 69%, transparent 69%);
-    background-size: 1.1rem 100%;
-    bottom: 0;
-    content: "";
-    height: .475rem;
-    left: 0;
-    position: absolute;
-    width: 100%;
-  }
 
   .from-price {
     color: $color-text;


### PR DESCRIPTION
Based on merchandising visual identity, we removed stripes from promotional pricetag

before: 
![image](https://user-images.githubusercontent.com/1045308/28137331-463f3d42-6723-11e7-97ad-5d1e7a297790.png)

afeter:
![image](https://user-images.githubusercontent.com/1045308/28137348-58ece87c-6723-11e7-8e72-06b95afb99bb.png)
