### PR TITLE
fix(tooltip): add zindex to prevent it for staying behind

### DIFF
--- a/src/css/atoms/tooltip.css
+++ b/src/css/atoms/tooltip.css
@@ -9,6 +9,7 @@
   position: absolute;
   transition: opacity .3s ease-in-out, visibility .6s;
   visibility: hidden;
+  z-index: $index-ahead;
 
   &::after {
     border-style: solid;


### PR DESCRIPTION
## before
![image](https://user-images.githubusercontent.com/15933/28181034-8a208966-67dd-11e7-8f29-a3140f9f405f.png)

## after
![image](https://user-images.githubusercontent.com/15933/28181039-907079ca-67dd-11e7-867d-562be410f43d.png)
