### PR TITLE
fix(addon): remove pointer-event from addon

### DIFF
--- a/src/css/atoms/form/addon.css
+++ b/src/css/atoms/form/addon.css
@@ -1,6 +1,7 @@
 .addon {
   color: $color-text;
   padding-top: .7rem;
+  pointer-events: none;
   position: absolute;
   text-align: center;
   width: 2rem;

--- a/src/css/atoms/form/field.css
+++ b/src/css/atoms/form/field.css
@@ -6,6 +6,7 @@
     border-radius: 1rem;
     content: " ";
     height: 1.12rem;
+    pointer-events: none;
     position: absolute;
     right: .12rem;
     top: 1rem;


### PR DESCRIPTION
Update the addon to have point-events equals none at fields and addon style.

## before:
![eita](https://user-images.githubusercontent.com/17216397/28182194-aee17c98-67e1-11e7-9290-a09c56a702f9.gif)

## after:
![boa](https://user-images.githubusercontent.com/17216397/28182184-a6fbdbb8-67e1-11e7-9ba1-4b0b579e7d5e.gif)
