### PR TITLE
fix(confirm): button alignment grid

### DIFF
--- a/src/js/components/confirm.js
+++ b/src/js/components/confirm.js
@@ -71,12 +71,12 @@ class Confirm {
               <p data-confirm-text>${textMessage}</p>
             </div>
             <div class="row">
-              <div class="col-xs-offset-2 col-xs-5 col-md-4">
+              <div class="col-xs-6 col-sm-push-1 col-sm-5 col-lg-push-2 col-lg-4">
                 <button class="button button-primary button-full" data-confirm-button>
                   ${textConfirmButton}
                 </button>
               </div>
-              <div class="col-xs-5 col-md-4">
+              <div class="col-xs-6 col-sm-push-1 col-sm-5 col-lg-push-2 col-lg-4">
                 <button class="button button-full" data-cancel-button>
                   ${textCancelButton}
                 </button>


### PR DESCRIPTION
Buttons inside confirm modal were misaligned only in mobile, but did a small change in grind

### before
![image](https://user-images.githubusercontent.com/1045308/28282169-e5f07b0a-6aff-11e7-93ea-d60acc56a2b3.png)

### after
![image](https://user-images.githubusercontent.com/1045308/28282319-65bbcbb4-6b00-11e7-8167-2d8513cf7ae3.png)
![image](https://user-images.githubusercontent.com/1045308/28282327-7009d8b8-6b00-11e7-8030-dac657192749.png)
![image](https://user-images.githubusercontent.com/1045308/28282340-78a847e8-6b00-11e7-8abe-ec86c3524ac5.png)
