### PR TITLE
fix(addon): reverting pointer-events on addon css class

### DIFF
--- a/src/css/atoms/form/addon.css
+++ b/src/css/atoms/form/addon.css
@@ -1,7 +1,6 @@
 .addon {
   color: $color-text;
   padding-top: .7rem;
-  pointer-events: none;
   position: absolute;
   text-align: center;
   width: 2rem;

--- a/src/css/atoms/form/field.css
+++ b/src/css/atoms/form/field.css
@@ -6,7 +6,6 @@
     border-radius: 1rem;
     content: " ";
     height: 1.12rem;
-    pointer-events: none;
     position: absolute;
     right: .12rem;
     top: 1rem;


### PR DESCRIPTION
When pointer-events is set to none, is not possible to trigger a click event on the addon glyph.
Revert the PR #264 that set pointer-events to none on addon.
