### PR TITLE
refactor(trigger-event): update constructor for Event objects

### DIFF
--- a/src/js/utils/trigger-event.js
+++ b/src/js/utils/trigger-event.js
@@ -1,6 +1,5 @@
-export default (element, type) => {
-  const event = document.createEvent('HTMLEvents')
-  event.initEvent(type, false, true)
+export default (element, type, options = {}) => {
+  const event = new Event(type, options)
 
   return element.dispatchEvent(event)
 }

--- a/test/utils/trigger-event.spec.js
+++ b/test/utils/trigger-event.spec.js
@@ -8,11 +8,9 @@ describe('triggerEvent util', () => {
   })
 
   it('should trigger the event passed as parameter', sinon.test(function () {
-    const spy = this.stub(element, 'dispatchEvent')
-    const eventObject = document.createEvent('HTMLEvents')
+    const spy = this.spy(element, 'dispatchEvent')
     const eventName = 'click'
-
-    eventObject.initEvent(eventName, false, true)
+    const eventObject = new Event(eventName)
 
     triggerEvent(element, eventName)
 


### PR DESCRIPTION
As the constructor we were using before was deprecated, I find it interesting to update it. Also, I needed to pass an event options object as a parameter to this `util`, so I updated that as well.

![tmp](http://www.clipular.com/c/6256216895651840.png?k=sMS0gnGcDRvYSCwGzbeykdNAFRA)