### PR TITLE
fix(modal): always emit modal:hide

### DIFF
--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -96,7 +96,9 @@ class Modal {
 
   bindModalHideListener () {
     emitter.on('modal:hide', () => {
-      history.back()
+      if (window.location.hash) {
+        return history.back()
+      }
     })
   }
 
@@ -140,9 +142,7 @@ class Modal {
   }
 
   hideModal () {
-    if (window.location.hash) {
-      emitter.emit('modal:hide')
-    }
+    emitter.emit('modal:hide')
     emitter.removeAllListeners('modal:hide')
 
     this.$content

--- a/test/components/modal.spec.js
+++ b/test/components/modal.spec.js
@@ -288,18 +288,33 @@ describe('Modal spec', () => {
   })
 
   describe('bindModalHideListener', () => {
-    it('should call `history.back` when `modal:hide` is emitted',
-      sinon.test(function () {
-        const spy = this.spy(history, 'back')
-        instance.init()
-        instance.options.history = true
-        instance.show()
+    context('when modal:hide event is emitted', () => {
+      context('when window.location has hash', () => {
+        it('should call history.back', sinon.test(function () {
+          const spy = this.spy(history, 'back')
 
-        emitter.emit('modal:hide')
+          window.location.hash = '#modal-open'
 
-        expect(spy.calledOnce).to.be.true
+          instance.bindModalHideListener()
+
+          emitter.emit('modal:hide')
+
+          expect(spy.calledOnce).to.be.true
+        }))
       })
-    )
+
+      context('when window.location has no hash', () => {
+        it('should not call history.back', sinon.test(function () {
+          const spy = this.spy(history, 'back')
+
+          instance.bindModalHideListener()
+
+          emitter.emit('modal:hiden')
+
+          expect(spy.notCalled).to.be.true
+        }))
+      })
+    })
   })
 
   describe('unbindListeners', () => {
@@ -419,32 +434,14 @@ describe('Modal spec', () => {
   })
 
   describe('hideModal', () => {
-    context('when there is a hash in the location path', () => {
-      it('should emit `modal:hide`', sinon.test(function () {
-        const spy = this.spy(emitter, 'emit')
-        const hash = '#modal-open'
+    it('should emit `modal:hide`', sinon.test(function () {
+      const spy = this.spy(emitter, 'emit')
 
-        window.location.hash = hash
+      instance.init()
+      instance.hideModal()
 
-        instance.init()
-        instance.hideModal()
-
-        expect(spy.calledWith('modal:hide')).to.be.true
-      }))
-    })
-
-    context('when there is not a hash in the location path', () => {
-      it('should not emit `modal:hide`', sinon.test(function () {
-        const spy = this.spy(emitter, 'emit')
-
-        window.location.hash = ''
-
-        instance.init()
-        instance.hideModal()
-
-        expect(spy.calledWith('modal:hide')).to.be.false
-      }))
-    })
+      expect(spy.calledWith('modal:hide')).to.be.true
+    }))
 
     it('should remove `modal:hide` listener from emitter',
       sinon.test(function () {


### PR DESCRIPTION
On show method, we always emit `modal:show` but in hide method we just emit this event when history feature is enabled. This pr makes hide methodo always emit `modal:hide`